### PR TITLE
12-Headers Class

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,7 +1,10 @@
 import commons.header.Header;
+import commons.headers.Headers;
 import producer.ProducerRecord;
 
+import javax.sound.midi.SysexMessage;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Main {
@@ -43,7 +46,26 @@ public class Main {
 
     }
 
+    public static void headersTest() {
+        String key1 = "Kyoshi";
+        String key2 = "Bob";
+        Headers headers = new Headers();
+        headers.add(key1, "22".getBytes());
+        headers.add(key1, "29".getBytes());
+        headers.add(key1, "22".getBytes());
+        headers.add(key2, "51".getBytes());
+        headers.add(key2, "23".getBytes());
+        headers.add(key2, "58".getBytes());
+
+        ArrayList<Header> kyoshiKeys = (ArrayList<Header>) headers.headers(key1);
+        ArrayList<Header> bobKeys = (ArrayList<Header>) headers.headers(key2);
+
+        System.out.println(kyoshiKeys);
+        System.out.println(bobKeys);
+    }
+
     public static void main(String[] args) {
-        producerRecordTest();
+//        producerRecordTest();
+        headersTest();
     }
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -2,9 +2,7 @@ import commons.header.Header;
 import commons.headers.Headers;
 import producer.ProducerRecord;
 
-import javax.sound.midi.SysexMessage;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class Main {

--- a/src/main/java/commons/headers/Headers.java
+++ b/src/main/java/commons/headers/Headers.java
@@ -1,0 +1,85 @@
+package commons.headers;
+
+import commons.header.Header;
+
+import java.util.*;
+
+public class Headers implements HeadersInterface {
+    private final HashMap<String, ArrayList<Header>> hashMap = new LinkedHashMap<>();
+
+    @Override
+    public HeadersInterface add(String key, byte[] value) throws IllegalStateException {
+        Header newHeader = new Header(key, value);
+        // First time keys
+        if (!hashMap.containsKey(key)) {
+            hashMap.put(key, new ArrayList<>());
+            hashMap.get(key).add(newHeader);
+        } else {
+            hashMap.get(key).add(newHeader);
+        }
+        return this;
+    }
+
+    @Override
+    public HeadersInterface add(Header header) throws IllegalStateException {
+        String key = header.getKey();
+        // First time keys
+        if (!hashMap.containsKey(key)) {
+            hashMap.put(key, new ArrayList<>());
+            hashMap.get(key).add(header);
+        } else {
+            hashMap.get(key).add(header);
+        }
+        return this;
+    }
+
+    @Override
+    public HeadersInterface remove(String key) throws IllegalStateException {
+        // Key does not exist
+        if (!hashMap.containsKey(key)) {
+            throw new IllegalArgumentException("Key not found.");
+        }
+
+        hashMap.get(key).clear();
+        return this;
+    }
+
+    @Override
+    public Iterable<Header> headers(String key) {
+        // Key does not exist
+        if (!hashMap.containsKey(key)) {
+            throw new IllegalArgumentException("Key not found.");
+        }
+        return hashMap.get(key);
+    }
+
+    @Override
+    public Header lastHeader(String key) {
+        // Key does not exist
+        if (!hashMap.containsKey(key)) {
+            throw new IllegalArgumentException("Key not found.");
+        }
+
+        ArrayList<Header> headers = hashMap.get(key);
+        return headers.get(headers.size() - 1);
+    }
+
+    @Override
+    public Header[] toArray() {
+        List<Header> allHeaders = new ArrayList<>();
+        for (ArrayList<Header> headerList : hashMap.values()) {
+            allHeaders.addAll(headerList);
+        }
+
+        return allHeaders.toArray(new Header[0]);
+    }
+
+    @Override
+    public Iterator<Header> iterator() {
+        List<Header> allHeaders = new ArrayList<>();
+        for (ArrayList<Header> headerList : hashMap.values()) {
+            allHeaders.addAll(headerList);
+        }
+        return allHeaders.iterator();
+    }
+}

--- a/src/main/java/commons/headers/Headers.java
+++ b/src/main/java/commons/headers/Headers.java
@@ -26,10 +26,8 @@ public class Headers implements HeadersInterface {
         // First time keys
         if (!hashMap.containsKey(key)) {
             hashMap.put(key, new ArrayList<>());
-            hashMap.get(key).add(header);
-        } else {
-            hashMap.get(key).add(header);
         }
+        hashMap.get(key).add(header);
         return this;
     }
 

--- a/src/main/java/commons/headers/HeadersInterface.java
+++ b/src/main/java/commons/headers/HeadersInterface.java
@@ -1,0 +1,13 @@
+package commons.headers;
+
+import commons.header.Header;
+
+public interface HeadersInterface extends Iterable<Header> {
+    HeadersInterface add(String key, byte[] value) throws IllegalStateException;
+    HeadersInterface add(Header header) throws IllegalStateException;
+    HeadersInterface remove(String key) throws IllegalStateException;
+    Iterable<Header> headers(String key);
+    Header lastHeader(String key);
+    Header[] toArray();
+
+}


### PR DESCRIPTION
## Description
This pull request introduces the `Headers` class, which represents a collection of `Header` objects.

- The `Headers` class uses a `HashMap` of type: `HashMap<String, ArrayList<Header>>`. 
  - Each key in the map represents a unique identifier.
  - The associated value is a list of `Header` objects, all sharing the same key but potentially having different values.
- The `ArrayList<Header>` ensures that multiple headers with the same key can be stored and maintained in insertion order.
- This implementation supports adding, removing, and retrieving headers based on their keys.

### Key Features:
- Each key maps to a collection (`ArrayList`) of `Header` objects.
- All `Header` objects in a given list share the same key but can have different values.

### Screenshot
<img width="730" alt="Screenshot 2024-12-27 at 9 15 22 PM" src="https://github.com/user-attachments/assets/a0b7c3a4-3d66-4171-9c39-7de994eb60af" />

<img width="797" alt="Screenshot 2024-12-27 at 9 15 08 PM" src="https://github.com/user-attachments/assets/f47ab72e-b190-4c81-affb-04c40f3ef424" />

### Story Reference:
- Story #12
- Docs: [Apache Kafka Headers](https://kafka.apache.org/25/javadoc/org/apache/kafka/common/header/Headers.html)
