### PR TITLE
#5 - Basic Producer Infrastructure

### DIFF
--- a/src/main/java/producer/FluxProducer.java
+++ b/src/main/java/producer/FluxProducer.java
@@ -1,20 +1,20 @@
 package producer;
 
+import commons.header.Properties;
+
 import java.util.Map;
-import java.util.Properties;
 
 public class FluxProducer<K, V> implements Producer {
-    private Map<String, Object> configs;
+    private Map<String, String> configs;
     // TODO: Include RecordAccumulator once implemented
 
-    public FluxProducer(Map<String, Object> configs) {
+    public FluxProducer(Map<String, String> configs) {
         this.configs = configs;
     }
 
-    // TODO: Replace with Properties object once implemented
-//    public FluxProducer(properties obj) {
-//
-//    }
+    public FluxProducer(Properties props) {
+        this.configs = props.getAllProperties();
+    }
 
     @Override
     public boolean send(ProducerRecord record) {

--- a/src/main/java/producer/FluxProducer.java
+++ b/src/main/java/producer/FluxProducer.java
@@ -1,0 +1,29 @@
+package producer;
+
+import java.util.Map;
+import java.util.Properties;
+
+public class FluxProducer<K, V> implements Producer {
+    private Map<String, Object> configs;
+    // TODO: Include RecordAccumulator once implemented
+
+    public FluxProducer(Map<String, Object> configs) {
+        this.configs = configs;
+    }
+
+    // TODO: Replace with Properties object once implemented
+//    public FluxProducer(properties obj) {
+//
+//    }
+
+    @Override
+    public boolean send(ProducerRecord record) {
+        // TODO: implementation of this method depends on RecordAccumulator to be done
+        return false;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/src/main/java/producer/Producer.java
+++ b/src/main/java/producer/Producer.java
@@ -1,0 +1,6 @@
+package producer;
+
+public interface Producer<K, V> {
+    boolean send(ProducerRecord<K,V> record);
+    void close();
+}


### PR DESCRIPTION
Implemented a super barebones Producer infrastructure, this infrastructure requires on other features like `RecordAccumulator` to be implemented first

refactor required later based on the TODO comments

**Reference material(s):**
- https://kafka.apache.org/27/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html
- https://docs.google.com/document/d/1f2O1PUuRMhnr-cRLTUwgSuATVTisJR1b7dy7i_ISF-E/edit?usp=sharing

**Infrastructure requirements:**
- [x] `Producer<K, V>` interface
- [x] `FluxProducer` class

**Functional requirements:**
- [x] `send(Record<K,V>)` (SKELETON)
- [x] `close()` (SKELETON)