### PR TITLE
22 - Write RecordBatch to disk (LogSegment)

### DIFF
--- a/src/main/java/broker/LogSegment.java
+++ b/src/main/java/broker/LogSegment.java
@@ -1,10 +1,13 @@
 package broker;
 
 import org.tinylog.Logger;
-import producer.ProducerRecord;
+import producer.RecordBatch;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A LogSegment is a component/storage unit that makes up a Flux Partition.
@@ -52,9 +55,35 @@ public class LogSegment {
         this.isActive = false;
     }
 
-    // TODO: Implement below method once RecordBatch is implemented
-    public boolean writeBatchToSegment() {
-        return true;
+    public void writeBatchToSegment(RecordBatch batch) throws IOException {
+        if (this.currentSizeInBytes >= segmentThresholdInBytes) {
+            Logger.info("Log segment has become immutable, new one may be necessary.");
+            setAsImmutable();
+            return;
+        }
+        if (!isActive || batch.getCurrBatchSizeInBytes() == 0 || batch == null) {
+            Logger.warn("Batch either immutable, empty, or null.");
+            return;
+        }
+        if (this.currentSizeInBytes + batch.getCurrBatchSizeInBytes() > segmentThresholdInBytes) {
+            Logger.warn("Size of batch exceeds log segment threshold.");
+            return;
+        }
+
+        // grab the buffer and throw the occupied space in the buffer to a byte arr that will be written to disk
+        ByteBuffer buffer = batch.getBatchBuffer().flip();
+        byte[] occupiedData = new byte[batch.getCurrBatchSizeInBytes()];
+        buffer.get(occupiedData); // transfers bytes from buffer --> occupiedData
+
+        try {
+            // write occupied data to the log file
+            Files.write(Path.of(logFile.getPath()), occupiedData);
+            this.currentSizeInBytes += occupiedData.length;
+            Logger.info("Batch successfully written to segment.");
+        } catch (IOException e) {
+            Logger.error("Failed to write batch to log segment. Error: " + e.getMessage(), e);
+            throw new IOException();
+        }
     }
 
     public boolean isActive() {

--- a/src/test/java/broker/LogSegmentTest.java
+++ b/src/test/java/broker/LogSegmentTest.java
@@ -1,8 +1,10 @@
 package broker;
 
 import org.junit.jupiter.api.Test;
+import producer.RecordBatch;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 // TODO: Fix failing test cases due to missing file, "./data/partition%d_%05d.log"
 public class LogSegmentTest {
@@ -13,8 +15,27 @@ public class LogSegmentTest {
     }
 
     @Test
-    public void overloadedLogSegmentConstructorTest() throws  IOException {
+    public void overloadedLogSegmentConstructorTest() throws IOException {
         LogSegment logSegment = new LogSegment(0,1,231L);
         System.out.println(logSegment);
+    }
+
+    @Test
+    public void writeBatchToSegmentTest() throws IOException {
+        LogSegment segment = new LogSegment(0, 0);
+        RecordBatch batch = new RecordBatch();
+
+        try {
+            // append fake data
+            batch.append(new byte[]{1, 3, 2, 4, 9, 12, 34, 123, 93});
+            batch.append(new byte[]{45, 4, 85, 5, 9, 12, 34, 123, 93});
+            batch.append(new byte[]{14, 6, 72, 1, 121, 31, 34, 123, 93});
+            batch.append(new byte[]{90, 3, 2, 0, 102, 12, 34, 123, 93});
+
+            // should print "INFO: Batch successfully written to segment."
+            segment.writeBatchToSegment(batch);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/test/java/broker/LogSegmentTest.java
+++ b/src/test/java/broker/LogSegmentTest.java
@@ -3,8 +3,11 @@ package broker;
 import org.junit.jupiter.api.Test;
 import producer.RecordBatch;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 // TODO: Fix failing test cases due to missing file, "./data/partition%d_%05d.log"
 public class LogSegmentTest {
@@ -25,17 +28,20 @@ public class LogSegmentTest {
         LogSegment segment = new LogSegment(0, 0);
         RecordBatch batch = new RecordBatch();
 
-        try {
-            // append fake data
-            batch.append(new byte[]{1, 3, 2, 4, 9, 12, 34, 123, 93});
-            batch.append(new byte[]{45, 4, 85, 5, 9, 12, 34, 123, 93});
-            batch.append(new byte[]{14, 6, 72, 1, 121, 31, 34, 123, 93});
-            batch.append(new byte[]{90, 3, 2, 0, 102, 12, 34, 123, 93});
+        // append fake data
+        batch.append(new byte[]{1, 3, 2, 4, 9, 12, 34, 123, 93});
+        batch.append(new byte[]{45, 4, 85, 5, 9, 12, 34, 123, 93});
+        batch.append(new byte[]{14, 6, 72, 1, 121, 31, 34, 123, 93});
+        batch.append(new byte[]{90, 3, 2, 0, 102, 12, 34, 123, 93});
 
-            // should print "INFO: Batch successfully written to segment."
-            segment.writeBatchToSegment(batch);
-        } catch (IOException e) {
-            e.printStackTrace();
+        // should print "INFO: Batch successfully written to segment."
+        segment.writeBatchToSegment(batch);
+        File file = segment.getLogFile();
+
+        // read the bytes from the file and verify it matches the fake data above
+        byte[] readBytes = Files.readAllBytes(Path.of(file.getPath()));
+        for (byte b : readBytes) {
+            System.out.print(b + " ");
         }
     }
 }

--- a/src/test/java/producer/RecordBatchTest.java
+++ b/src/test/java/producer/RecordBatchTest.java
@@ -2,6 +2,8 @@ package producer;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 public class RecordBatchTest {
 
     @Test
@@ -17,7 +19,7 @@ public class RecordBatchTest {
     }
 
     @Test
-    public void addSerializedRecordToBatchTest() {
+    public void addSerializedRecordToBatchTest() throws IOException {
         RecordBatch batch = new RecordBatch();
         byte[] record = {10, 39, 122, 19, 93, 34, 9};
         boolean res = batch.append(record);


### PR DESCRIPTION
The `LogSegment` class is responsible for a subset of the partition's overall data, and this segment may contain 1 or more `RecordBatches`. Thus, we need functionality within the LogSegment class to efficiently write entire batches to disk (aka to the data file).

**Functional requirements**:
- [x] Implement the `writeBatchToSegment` method which should take in a `RecordBatch` and write it to the data file within the particular segment
- [x] Refactor the `RecordBatch` class to use a ByteBuffer instead of List<byte[]> to better group up all the records into 1 big byte accumulator so I can just dump it onto disk in 1 go instead of going record by record 
