### PR TITLE
9-Record Accumulator

### DIFF
--- a/src/main/java/producer/FluxProducer.java
+++ b/src/main/java/producer/FluxProducer.java
@@ -2,11 +2,12 @@ package producer;
 
 import commons.header.Properties;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class FluxProducer<K, V> implements Producer {
     private Map<String, String> configs;
-    // TODO: Include RecordAccumulator once implemented
+    RecordAccumulator recordAccumulator = new RecordAccumulator();
 
     public FluxProducer(Map<String, String> configs) {
         this.configs = configs;
@@ -17,12 +18,13 @@ public class FluxProducer<K, V> implements Producer {
     }
 
     @Override
-    public void send(ProducerRecord record) {
-        // TODO: implementation of this method depends on RecordAccumulator to be done
+    public void send(ProducerRecord record) throws IOException {
+        byte[] serializedData = ProducerRecordCodec.serialize(record, record.getKey().getClass(), record.getValue().getClass());
+        recordAccumulator.append(serializedData);
     }
 
     @Override
     public void close() {
-
+        //TODO: RecordAccumulator should flush any remaining records
     }
 }

--- a/src/main/java/producer/Producer.java
+++ b/src/main/java/producer/Producer.java
@@ -1,6 +1,8 @@
 package producer;
 
+import java.io.IOException;
+
 public interface Producer<K, V> {
-    void send(ProducerRecord<K,V> record);
+    void send(ProducerRecord<K,V> record) throws IOException;
     void close();
 }

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -1,0 +1,42 @@
+package producer;
+
+public class RecordAccumulator {
+    static private final int DEFAULT_BATCH_SIZE =  16_384; // 16 bytes
+
+    //TODO: Future work for multiple partitions
+//    private Map<TopicPartition, RecordBatch> batches;
+
+    private final int batchSize;
+
+    public RecordAccumulator(){
+        this.batchSize = validateBatchSize(DEFAULT_BATCH_SIZE);
+    }
+
+    public RecordAccumulator(int batchSize) {
+        this.batchSize = validateBatchSize(batchSize);
+    }
+
+    public RecordBatch createBatch(int partition, long baseOffset) {
+
+        return new RecordBatch();
+    }
+    public boolean flush() {
+        return false;
+    }
+
+    public void append(byte[] serializedRecord) {
+
+    }
+
+    private int validateBatchSize(int batchSize) {
+        final int MIN_BATCH_SIZE = 1; // validate its non-zero
+        final int MAX_BATCH_SIZE = 1_048_576; // Anything above 1 MB seems unreasonable.
+
+        if (batchSize < MIN_BATCH_SIZE || batchSize > MAX_BATCH_SIZE) {
+            throw new IllegalArgumentException(
+                    ". Batch size must be between " + MIN_BATCH_SIZE + "-" + MAX_BATCH_SIZE + " bytes."
+            );
+        }
+        return batchSize;
+    }
+}

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -1,14 +1,16 @@
 package producer;
 
-public class RecordAccumulator {
-    static private final int DEFAULT_BATCH_SIZE =  16_384; // 16 bytes
+import org.tinylog.Logger;
 
-    //TODO: Future work for multiple partitions
-//    private Map<TopicPartition, RecordBatch> batches;
+import java.io.IOException;
+
+public class RecordAccumulator {
+    static private final int DEFAULT_BATCH_SIZE = 10_240; // 10 KB
 
     private final int batchSize;
+    private RecordBatch currentBatch; // Active batch for the single partition
 
-    public RecordAccumulator(){
+    public RecordAccumulator() {
         this.batchSize = validateBatchSize(DEFAULT_BATCH_SIZE);
     }
 
@@ -17,24 +19,41 @@ public class RecordAccumulator {
     }
 
     public RecordBatch createBatch(int partition, long baseOffset) {
-
-        return new RecordBatch();
+        Logger.info("Creating new batch for partition " + partition + " with baseOffset " + baseOffset);
+        return new RecordBatch(batchSize);
     }
+
+    //TODO: Broker class missing
     public boolean flush() {
-        return false;
+        Logger.info("Flushing the batch to the broker (Stubbed out)");
+        return true;
     }
 
-    public void append(byte[] serializedRecord) {
+    public void append(byte[] serializedRecord) throws IOException {
+        // Single assumption
+        int partition = 0;
+        long baseOffset = 0L;
 
+        // Check if current batch exists or is full
+        if (currentBatch == null || !currentBatch.append(serializedRecord)) {
+            Logger.info("Batch is full or not present. Creating a new batch.");
+            currentBatch = createBatch(partition, baseOffset);
+
+            if (!currentBatch.append(serializedRecord)) {
+                throw new IllegalStateException("Serialized record cannot fit into a new batch. Check batch size configuration.");
+            }
+        }
+
+        Logger.info("Record appended successfully.");
     }
 
     private int validateBatchSize(int batchSize) {
-        final int MIN_BATCH_SIZE = 1; // validate its non-zero
-        final int MAX_BATCH_SIZE = 1_048_576; // Anything above 1 MB seems unreasonable.
+        final int MIN_BATCH_SIZE = 1; // Minimum size
+        final int MAX_BATCH_SIZE = 1_048_576; // 1 MB
 
         if (batchSize < MIN_BATCH_SIZE || batchSize > MAX_BATCH_SIZE) {
             throw new IllegalArgumentException(
-                    ". Batch size must be between " + MIN_BATCH_SIZE + "-" + MAX_BATCH_SIZE + " bytes."
+                    "Batch size must be between " + MIN_BATCH_SIZE + "-" + MAX_BATCH_SIZE + " bytes."
             );
         }
         return batchSize;

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -32,16 +32,19 @@ public class RecordAccumulator {
     public void append(byte[] serializedRecord) throws IOException {
         // Single assumption
         int partition = 0;
-        long baseOffset = 0L;
+        int baseOffset = 0;
 
         // Check if current batch exists or is full
-        if (currentBatch == null || !currentBatch.append(serializedRecord)) {
+        if (currentBatch == null) {
             Logger.info("Batch is full or not present. Creating a new batch.");
             currentBatch = createBatch(partition, baseOffset);
 
             if (!currentBatch.append(serializedRecord)) {
                 throw new IllegalStateException("Serialized record cannot fit into a new batch. Check batch size configuration.");
             }
+        }  // batch is full
+        else if(!currentBatch.append(serializedRecord)) {
+            flush(); // TODO: Missing flush() method
         }
 
         Logger.info("Record appended successfully.");

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -47,6 +47,21 @@ public class RecordAccumulator {
         Logger.info("Record appended successfully.");
     }
 
+    public RecordBatch getCurrentBatch() {
+        return currentBatch;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void printRecord() {
+        System.out.println("Batch Size: " + getBatchSize());
+        System.out.println("Current Batch:");
+
+        getCurrentBatch().printBatchDetails();
+    }
+
     private int validateBatchSize(int batchSize) {
         final int MIN_BATCH_SIZE = 1; // Minimum size
         final int MAX_BATCH_SIZE = 1_048_576; // 1 MB

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -33,21 +33,26 @@ public class RecordAccumulator {
         // Single assumption
         int partition = 0;
         int baseOffset = 0;
+        try {
+            // Check if current batch exists or is full
+            if (currentBatch == null) {
+                Logger.info("Batch is full or not present. Creating a new batch.");
+                currentBatch = createBatch(partition, baseOffset);
 
-        // Check if current batch exists or is full
-        if (currentBatch == null) {
-            Logger.info("Batch is full or not present. Creating a new batch.");
-            currentBatch = createBatch(partition, baseOffset);
-
-            if (!currentBatch.append(serializedRecord)) {
-                throw new IllegalStateException("Serialized record cannot fit into a new batch. Check batch size configuration.");
+                if (!currentBatch.append(serializedRecord)) {
+                    throw new IllegalStateException("Serialized record cannot fit into a new batch. Check batch size configuration.");
+                }
+            }  // batch is full
+            else if(!currentBatch.append(serializedRecord)) {
+                Logger.info("Batch is full. Flushing current batch and creating a new one.");
+                flush(); // TODO: Missing flush() method
             }
-        }  // batch is full
-        else if(!currentBatch.append(serializedRecord)) {
-            flush(); // TODO: Missing flush() method
+            Logger.info("Record appended successfully.");
+
+        } catch(Exception e) {
+            Logger.error("Failed to append record: " + e.getMessage(), e);
         }
 
-        Logger.info("Record appended successfully.");
     }
 
     public RecordBatch getCurrentBatch() {

--- a/src/test/java/broker/LogSegmentTest.java
+++ b/src/test/java/broker/LogSegmentTest.java
@@ -19,7 +19,7 @@ public class LogSegmentTest {
 
     @Test
     public void overloadedLogSegmentConstructorTest() throws IOException {
-        LogSegment logSegment = new LogSegment(0,1,231L);
+        LogSegment logSegment = new LogSegment(0,1, 231);
         System.out.println(logSegment);
     }
 

--- a/src/test/java/producer/RecordAccumulatorTest.java
+++ b/src/test/java/producer/RecordAccumulatorTest.java
@@ -1,0 +1,30 @@
+package producer;
+
+import commons.header.Header;
+import commons.headers.Headers;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class RecordAccumulatorTest {
+    @Test
+    public void appendTest() throws IOException {
+        // Setup
+        Headers headers = new Headers();
+        headers.add(new Header("Kyoshi", "22".getBytes()));
+        ProducerRecord<String, String> record = new ProducerRecord<>(
+                "Bob",
+                0,
+                System.currentTimeMillis(),
+                "key",
+                "22",
+                headers
+        );
+        byte[] serializedData = ProducerRecordCodec.serialize(record, String.class, String.class);
+
+        // Execute
+        RecordAccumulator recordAccumulator = new RecordAccumulator();
+        recordAccumulator.append(serializedData);
+        recordAccumulator.printRecord();
+    }
+}


### PR DESCRIPTION
### Description 
- Basic outline of `RecordAccumulator` class
   - `createBatch(int partition, long baseOffset)` => `RecordBatch`
   -  `append(byte[] serializedRecord) throws IOException` => void
   - `validateBatchSize(int batchSize)` => int
- Had to stub out flush() method due to `Broker` class missing.
- Validates `batchSize` before initializing it 
- instantiate a `RecordAccumulator` to `FluxProducer` 

### Screenshot

<img width="772" alt="Screenshot 2025-01-04 at 10 01 40 PM" src="https://github.com/user-attachments/assets/0bbe3f85-7f9a-47ef-8f09-31eee24ab882" />
