### PR TITLE
21 - LogSegment index file

### DIFF
--- a/src/main/java/broker/LogSegment.java
+++ b/src/main/java/broker/LogSegment.java
@@ -26,8 +26,12 @@ public class LogSegment {
     private int currentSizeInBytes;
     private int startOffset; // for entire segment
     private int endOffset; // for entire segment
-    private ByteBuffer buffer;
+    private IndexEntries entries;
 
+    /**
+     * Represents a Record Offset --> Byte Offset pair
+     * NOTE: Full implementation depends on global record offset management to be implemented
+     */
     private class IndexEntries {
         public Map<Integer, Integer> recordOffsetToByteOffsets;
         private final int flushThreshold = 5; // test value, can adjust as needed
@@ -68,6 +72,7 @@ public class LogSegment {
     public LogSegment(int partitionNumber, int startOffset) throws IOException {
         this.partitionNumber = partitionNumber;
         this.startOffset = startOffset;
+        entries = new IndexEntries();
 
         try {
             // ex: partition1_000000.log, actual kafka names log files purely by byte offset like 000000123401.log
@@ -131,6 +136,7 @@ public class LogSegment {
             return;
         }
 
+
         // grab the buffer and throw the occupied space in the buffer to a byte arr that will be written to disk
         ByteBuffer buffer = batch.getBatchBuffer().flip();
         byte[] occupiedData = new byte[batch.getCurrBatchSizeInBytes()];
@@ -177,6 +183,10 @@ public class LogSegment {
 
     public int getEndOffset() {
         return endOffset;
+    }
+
+    public IndexEntries getEntries() {
+        return entries;
     }
 
     @Override


### PR DESCRIPTION
Implemented an `.index` file with every `LogSegment` which purpose is to map offsets (unique identifiers for records in Kafka) to their corresponding physical byte locations within the data file (.log). This allows Kafka, and our system, to quickly locate records by their offset which is important.

Created the `IndexEntries` as a private class as I don't believe we'll need access to it outside of the LogSegment. 

> [!NOTE]
> Full implementation will require global record offset management to be implemented which will most likely be through the broker (which is not yet implemented).  I tried to do some smaller-scale offset management but scrapped it.