### PR TITLE
Implement Support for Topic Creation

### DIFF
--- a/src/main/java/admin/FluxAdmin.java
+++ b/src/main/java/admin/FluxAdmin.java
@@ -46,11 +46,11 @@ public class FluxAdmin implements Admin {
         List<Topic> newTopicsList = new ArrayList<>();
         for (NewTopic topic : topics) {
             Topic newTopic = Topic
-                                        .newBuilder()
-                                        .setTopicName(topic.name())
-                                        .setNumPartitions(topic.numPartitions())
-                                        .setReplicationFactor(topic.replicationFactor())
-                                        .build();
+                                .newBuilder()
+                                .setTopicName(topic.name())
+                                .setNumPartitions(topic.numPartitions())
+                                .setReplicationFactor(topic.replicationFactor())
+                                .build();
             newTopicsList.add(newTopic);
         }
 

--- a/src/main/java/admin/FluxAdmin.java
+++ b/src/main/java/admin/FluxAdmin.java
@@ -41,16 +41,20 @@ public class FluxAdmin implements Admin {
         return instance;
     }
 
+    // NOTE: We have 3 ways to represent a topic, all used for different purposes.
+    // proto.Topic -> used to build proto messages
+    // admin.NewTopic -> plain object to represent initial metadata when building our gRPC request
+    // commons.FluxTopic -> the *actual* topic within our system. contains partitions and other info
     @Override
     public void createTopics(Collection<NewTopic> topics) {
-        List<Topic> newTopicsList = new ArrayList<>();
+        List<proto.Topic> newTopicsList = new ArrayList<>();
         for (NewTopic topic : topics) {
-            Topic newTopic = Topic
-                                .newBuilder()
-                                .setTopicName(topic.name())
-                                .setNumPartitions(topic.numPartitions())
-                                .setReplicationFactor(topic.replicationFactor())
-                                .build();
+            proto.Topic newTopic = proto.Topic
+                                    .newBuilder()
+                                    .setTopicName(topic.name())
+                                    .setNumPartitions(topic.numPartitions())
+                                    .setReplicationFactor(topic.replicationFactor())
+                                    .build();
             newTopicsList.add(newTopic);
         }
 

--- a/src/main/java/admin/FluxAdmin.java
+++ b/src/main/java/admin/FluxAdmin.java
@@ -62,7 +62,7 @@ public class FluxAdmin implements Admin {
         CreateTopicsResult response;
         try {
             response = blockingStub.createTopics(request);
-            System.out.println("CreateTopicsRequest Status: " + response.getStatus());
+            System.out.println(response.toString());
         } catch (Exception e) {
             e.printStackTrace();
             return;

--- a/src/main/java/admin/NewTopic.java
+++ b/src/main/java/admin/NewTopic.java
@@ -1,4 +1,6 @@
 package admin;
 
+// Does not represent a formal Topic object, this is just a plain object used by the Admin client when
+// building a createTopics request. Actual topic is validated + constructed by the Controller broker.
 public record NewTopic(String name, int numPartitions, int replicationFactor) {
 }

--- a/src/main/java/broker/Broker.java
+++ b/src/main/java/broker/Broker.java
@@ -3,11 +3,11 @@ package broker;
 import org.tinylog.Logger;
 import producer.RecordBatch;
 import proto.Message;
+import proto.Topic;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 public class Broker {
     private String brokerId;
@@ -17,16 +17,34 @@ public class Broker {
     private Partition partition;
     private int nextAvailOffset; // record offsets
 
+    Map<String, List<Partition>> topicMetadata;
+
     public Broker(String brokerId, String host, int port) throws IOException {
         this.brokerId = brokerId;
         this.host = host;
         this.port = port;
         this.partition = new Partition(1);
         this.nextAvailOffset = 0;
+        this.topicMetadata = new HashMap<>();
     }
 
     public Broker() throws IOException {
         this("BROKER-1", "localhost", 50051);
+    }
+
+    public void createTopics(Collection<Topic> topics) throws IOException {
+        // right now just worry about creating 1 topic
+        String topicName = topics.stream().toList().get(0).getTopicName();
+        int numPartitions = topics.stream().toList().get(0).getNumPartitions();
+        int replicationFactor = topics.stream().toList().get(0).getReplicationFactor();
+
+        ArrayList<Partition> partitions = new ArrayList<>();
+        for (int i = 0; i < numPartitions; i++) {
+            partitions.add(new Partition(2));
+        }
+
+        topicMetadata.put(topicName, partitions);
+        Logger.info("BROKER: Create topics completed successfully.");
     }
 
     public int produceSingleMessage(byte[] record) throws IOException {

--- a/src/main/java/broker/Broker.java
+++ b/src/main/java/broker/Broker.java
@@ -46,7 +46,6 @@ public class Broker {
         this("BROKER-1", "localhost", 50051, 1);
     }
 
-    // TODO: Finish below of whatever i was doing
     public void createTopics(Collection<proto.Topic> topics) throws IOException {
         // right now just worry about creating 1 topic
         String topicName = topics.stream().toList().getFirst().getTopicName();

--- a/src/main/java/commons/FluxTopic.java
+++ b/src/main/java/commons/FluxTopic.java
@@ -1,0 +1,29 @@
+package commons;
+
+import broker.Partition;
+
+import java.util.List;
+
+public class FluxTopic {
+    private String topicName;
+    private List<Partition> partitions;
+    private int replicationFactor;
+
+    public FluxTopic(String topicName, List<Partition> partitions, int replicationFactor) {
+        this.topicName = topicName;
+        this.partitions = partitions;
+        this.replicationFactor = replicationFactor;
+    }
+
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public List<Partition> getPartitions() {
+        return partitions;
+    }
+
+    public int getReplicationFactor() {
+        return replicationFactor;
+    }
+}

--- a/src/main/java/commons/IntRange.java
+++ b/src/main/java/commons/IntRange.java
@@ -1,0 +1,4 @@
+package commons;
+
+public record IntRange(int start, int end) {
+}

--- a/src/main/java/commons/utils/PartitionSelector.java
+++ b/src/main/java/commons/utils/PartitionSelector.java
@@ -62,7 +62,7 @@ public class PartitionSelector {
                 // At this point: No topic, no partition #, no key. Default to round-robin among all partitions in system.
                 // TODO: Should we insert topic-less records into partitions that belong to a particular topic? How to handle? Come back later
                 System.out.println("round robin triggering under NO topic, NO partition, NO key.");
-                System.out.printf("round robin counter = %d, numPartitions = %d", roundRobinCounter.getAndIncrement(), numPartitions);
+                System.out.printf("round robin counter = %d, numPartitions = %d", roundRobinCounter.get(), numPartitions);
                 return roundRobinCounter.getAndIncrement() % numPartitions;
             }
         } else { // Validate partition number

--- a/src/main/java/commons/utils/PartitionSelector.java
+++ b/src/main/java/commons/utils/PartitionSelector.java
@@ -1,6 +1,7 @@
 package commons.utils;
 
 import commons.IntRange;
+import exceptions.InvalidTopicException;
 import metadata.TopicMetadataRepository;
 import producer.MurmurHash2;
 
@@ -24,7 +25,7 @@ public class PartitionSelector {
         if (topicName != null && !topicName.isEmpty() && topicMetadata.topicExists(topicName)) {
             return getPartitionNumWhenTopicExists(topicMetadata, partitionNumber, key, topicName);
         } else {
-            return getPartitionNumWhenTopicDoesNotExist(topicMetadata, partitionNumber, key, numPartitions);
+            throw new InvalidTopicException(topicName);
         }
     }
 
@@ -62,6 +63,7 @@ public class PartitionSelector {
         }
     }
 
+    // Below method was replaced by just throwing an InvalidTopicException, however this can be used if we just want to throw records into any existing partition.
     private static int getPartitionNumWhenTopicDoesNotExist(TopicMetadataRepository topicMetadata, Integer partitionNumber, String key, int numPartitions) {
         // No partition number either, attempt key-based hashing.
         if (partitionNumber == null) {

--- a/src/main/java/commons/utils/PartitionSelector.java
+++ b/src/main/java/commons/utils/PartitionSelector.java
@@ -6,6 +6,17 @@ import producer.MurmurHash2;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Utility class to determine which partition a particular record should go to.
+ * Since multiple fields can help determine partition number, the priority ordering is as follows:
+ *      1. If a partition # is passed in to the record already, this takes top priority.
+ *          1a. Invalid partition numbers automatically get defaulted to round-robin.
+ *      2. If no partition number, attempt key-based hashing.
+ *      3. If no partition number and no key, default to round-robin.
+ *      4. If a topic is also passed in, this just narrows down which partitions we can select for the above operations.
+ *
+ * Note: The print statements are just for verifying correct selection. Should remove them at a later time when no longer necessary.
+ */
 public class PartitionSelector {
     private static AtomicInteger roundRobinCounter = new AtomicInteger(0);
 
@@ -32,6 +43,8 @@ public class PartitionSelector {
             } else {
                 // At this point: Yes topic, no partition #, no key. Default to round-robin within valid range.
                 // Jump to bottom of file for example of how this calculation works.
+                System.out.println("round robin triggering under topic exists, no partition, no key.");
+                System.out.printf("round robin counter = %d minPartition = %d maxPartition = %d range = %d%n", roundRobinCounter.getAndIncrement(), min, max, range);
                 return ((roundRobinCounter.getAndIncrement() - min) % range + range) % range + min;
             }
         } else { // Validate partition num is within topic's range of partitions.
@@ -42,6 +55,8 @@ public class PartitionSelector {
                 // What if it's out of range? Two subcases here:
                 // 1) Fallback to round-robin among this topic's partitions anyway.
                 // or 2) Throw InvalidPartitionException.
+                System.out.println("round robin triggering under topic exists, passed in partition #, no key.");
+                System.out.printf("round robin counter = %d minPartition = %d maxPartition = %d range = %d%n", roundRobinCounter.getAndIncrement(), min, max, range);
                 return ((roundRobinCounter.getAndIncrement() - min) % range + range) % range + min;
             }
         }
@@ -56,6 +71,8 @@ public class PartitionSelector {
             } else {
                 // At this point: No topic, no partition #, no key. Default to round-robin among all partitions in system.
                 // TODO: Should we insert topic-less records into partitions that belong to a particular topic? How to handle? Come back later
+                System.out.println("round robin triggering under NO topic, NO partition, NO key.");
+                System.out.printf("round robin counter = %d, numPartitions = %d", roundRobinCounter.getAndIncrement(), numPartitions);
                 return roundRobinCounter.getAndIncrement() % numPartitions;
             }
         } else { // Validate partition number
@@ -78,16 +95,19 @@ public class PartitionSelector {
         // The & 0x7fffffff operation is a faster way of doing Math.abs()
         // that also handles Integer.MIN_VALUE correctly.
         int positiveHash = hash & 0x7fffffff;
+        System.out.printf("Murmur2 hash returning = %d (no range)".formatted(positiveHash % numPartitions));
         return positiveHash % numPartitions;
     }
 
     public static int selectPartitionWithinRangeUsingMurmurHash2(String key, int min, int max) {
         if (key == null || key.isEmpty()) {
+            System.out.println("Empty/null key, returning = " + min);
             return min; // Instead of 0, our default partition will be the partition w/ the min ID
         }
         int hash = MurmurHash2.hash(key);
         int positiveHash = hash & 0x7fffffff;
-        return min + (positiveHash % max - min + 1);
+        System.out.printf("Murmur2 hash returning = %d within range [%d,%d]%n", min + (positiveHash % (max - min + 1)), min, max);
+        return min + (positiveHash % (max - min + 1));
     }
 }
 

--- a/src/main/java/commons/utils/PartitionSelector.java
+++ b/src/main/java/commons/utils/PartitionSelector.java
@@ -1,0 +1,86 @@
+package commons.utils;
+
+import commons.IntRange;
+import metadata.TopicMetadataRepository;
+import producer.MurmurHash2;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PartitionSelector {
+    private static AtomicInteger roundRobinCounter = new AtomicInteger(0);
+
+    public static int getPartitionNumberForRecord(TopicMetadataRepository topicMetadata, Integer partitionNumber, String key, String topicName, int numPartitions) {
+        if (topicName != null && !topicName.isEmpty() && topicMetadata.topicExists(topicName)) {
+            return getPartitionNumWhenTopicExists(topicMetadata, partitionNumber, key, topicName);
+        } else {
+            return getPartitionNumWhenTopicDoesNotExist(topicMetadata, partitionNumber, key, numPartitions);
+        }
+    }
+
+    private static int getPartitionNumWhenTopicExists(TopicMetadataRepository topicMetadata, Integer partitionNumber, String key, String topicName) {
+        IntRange validPartitionIdRange = topicMetadata.getPartitionIdRangeForTopic(topicName);
+        int min = validPartitionIdRange.start();
+        int max = validPartitionIdRange.end();
+        int range = max - min + 1;
+
+        // No partition number, attempt key-based hashing.
+        if (partitionNumber == null) {
+            // For records with a key, use MurmurHash2 for consistent hashing
+            if (key != null && !key.isEmpty()) {
+                // Must ensure that it selects a partition within this topic's range.
+                return MurmurHash2.selectPartitionWithinRange(key, min, max);
+            } else {
+                // At this point: Yes topic, no partition #, no key. Default to round-robin within valid range.
+                // Jump to bottom of file for example of how this calculation works.
+                return ((roundRobinCounter.getAndIncrement() - min) % range + range) % range + min;
+            }
+        } else { // Validate partition num is within topic's range of partitions.
+            // No need to handle key here because partition num takes priority over key in partition selection.
+            if (min <= partitionNumber && partitionNumber <= max) {
+                return partitionNumber;
+            } else {
+                // What if it's out of range? Two subcases here:
+                // 1) Fallback to round-robin among this topic's partitions anyway.
+                // or 2) Throw InvalidPartitionException.
+                return ((roundRobinCounter.getAndIncrement() - min) % range + range) % range + min;
+            }
+        }
+    }
+
+    private static int getPartitionNumWhenTopicDoesNotExist(TopicMetadataRepository topicMetadata, Integer partitionNumber, String key, int numPartitions) {
+        // No partition number either, attempt key-based hashing.
+        if (partitionNumber == null) {
+            // For records with a key, use MurmurHash2 for consistent hashing
+            if (key != null && !key.isEmpty()) {
+                return MurmurHash2.selectPartition(key, numPartitions);
+            } else {
+                // At this point: No topic, no partition #, no key. Default to round-robin among all partitions in system.
+                // TODO: Should we insert topic-less records into partitions that belong to a particular topic? How to handle? Come back later
+                return roundRobinCounter.getAndIncrement() % numPartitions;
+            }
+        } else { // Validate partition number
+            if (1 <= partitionNumber && partitionNumber <= numPartitions) {
+                return partitionNumber;
+            } else {
+                return roundRobinCounter.getAndIncrement() % numPartitions;
+            }
+        }
+    }
+}
+
+/**
+ * Example: our partition IDs for this topic range from 3..6 and roundRobinCounter returns 7
+ * ((7 - 3) % 4 + 4) % 4 + 3
+ * = ((4) % 4 + 4) % 4 + 3
+ * = (0 + 4) % 4 + 3
+ * = 4 % 4 + 3
+ * = 0 + 3
+ * = 3
+ *
+ * Example: our partition IDs for this topic range from 3..6 and roundRobinCounter returns 4
+ * ((4 - 3) % 4 + 4) % 4 + 3
+ * = ((1 % 4) + 4) % 4 + 3
+ * = (1 + 4) % 4 + 3
+ * = 5 % 4 + 3 = 1 + 3
+ * = 4
+ */

--- a/src/main/java/exceptions/InvalidPartitionException.java
+++ b/src/main/java/exceptions/InvalidPartitionException.java
@@ -1,0 +1,16 @@
+package exceptions;
+
+public class InvalidPartitionException extends RuntimeException {
+
+    public InvalidPartitionException(String exceptionMsg) {
+        super(exceptionMsg);
+    }
+
+    public InvalidPartitionException(int invalidPartition) {
+        super("Partition with id = " + invalidPartition + " either does not exist or is out of range");
+    }
+
+    public InvalidPartitionException(int invalidPartition, String topicName) {
+        super("Partition with id = " + invalidPartition + " either does not exist or is out of range for topic = {" + topicName + "}");
+    }
+}

--- a/src/main/java/exceptions/InvalidTopicException.java
+++ b/src/main/java/exceptions/InvalidTopicException.java
@@ -1,0 +1,7 @@
+package exceptions;
+
+public class InvalidTopicException extends RuntimeException {
+    public InvalidTopicException(String topicName) {
+        super("Topic \"%s\" does not exist. Please check your spelling or create the desired topic first.".formatted(topicName));
+    }
+}

--- a/src/main/java/grpc/BrokerServer.java
+++ b/src/main/java/grpc/BrokerServer.java
@@ -1,13 +1,10 @@
 package grpc;
 
 import broker.Broker;
-import com.google.protobuf.ByteString;
 import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.stub.StreamObserver;
-import metadata.BrokerMetadataRepository;
-import metadata.InMemoryBrokerMetadataRepository;
 import org.tinylog.Logger;
 import producer.IntermediaryRecord;
 import proto.*;

--- a/src/main/java/metadata/BrokerMetadataRepository.java
+++ b/src/main/java/metadata/BrokerMetadataRepository.java
@@ -1,0 +1,12 @@
+package metadata;
+
+import broker.Broker;
+
+import java.util.Set;
+
+public interface BrokerMetadataRepository {
+    void addBroker(String brokerId, Broker broker);
+    void updateBrokerPartitionCount(String brokerId, int newCount);
+    Set<String> getAllBrokerServerAddresses();
+    int getNumberOfPartitionsById(String brokerId);
+}

--- a/src/main/java/metadata/InMemoryBrokerMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryBrokerMetadataRepository.java
@@ -1,0 +1,57 @@
+package metadata;
+
+import broker.Broker;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Note: The real Kafka uses a Metadata API to fetch metadata directly from a given broker using network requests.
+ * This will be implemented here soon, but because this is quicker we are currently using an in memory solution like so.
+ * TODO: Implement proper Metadata API using gRPC in a separate ticket/PR.
+ */
+public class InMemoryBrokerMetadataRepository implements BrokerMetadataRepository {
+    Set<String> activeBrokerAddresses = new HashSet<>();
+    ConcurrentMap<String, Broker> map = new ConcurrentHashMap<>(); // brokerId -> { Broker }
+
+    private InMemoryBrokerMetadataRepository() {
+    }
+
+    // Bill Pugh Singleton - refer to InMemoryTopicMetadataRepository for quick explanation
+    private static class SingletonHelper {
+        private static final InMemoryBrokerMetadataRepository INSTANCE = new InMemoryBrokerMetadataRepository();
+    }
+
+    public static InMemoryBrokerMetadataRepository getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
+    @Override
+    public void addBroker(String brokerId, Broker broker) {
+        map.put(brokerId, broker);
+        activeBrokerAddresses.add("%s:%d".formatted(broker.getHost(), broker.getPort()));
+    }
+
+    @Override
+    public void updateBrokerPartitionCount(String brokerId, int newCount) {
+
+    }
+
+
+    @Override
+    public Set<String> getAllBrokerServerAddresses() {
+        return activeBrokerAddresses;
+    }
+
+    @Override
+    public int getNumberOfPartitionsById(String brokerId) {
+        if (!map.containsKey(brokerId)) {
+            throw new IllegalArgumentException("Broker ID " + brokerId + " does not exist");
+        }
+        return map.get(brokerId).getNumPartitions();
+    }
+
+
+}

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -43,8 +43,7 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
     @Override
     public boolean deleteTopic(String topicName) {
         if (topicMetadata.containsKey(topicName)) {
-            topicMetadata.remove(topicName);
-            return true;
+            return topicMetadata.remove(topicName) != null;
         }
         return false;
     }

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -4,6 +4,7 @@ import broker.Partition;
 import commons.FluxTopic;
 import commons.IntRange;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,6 +17,9 @@ import java.util.concurrent.ConcurrentMap;
  *
  * However, for simplicity reasons, we are (currently) implementing an in-memory approach to storing Topic metadata
  * using the Repository pattern. Down the line we will refactor to more closely align with Kafka's implementation.
+ *
+ * This is a Bill Pugh Singleton -- it loads the SingletonHelper and subsequently creates the InMemoryTopicMetadataRepository instance
+ * itself *only* when someone calls getInstance(). Avoids needing to do manual synchronization for multithreaded scenarios.
  */
 public class InMemoryTopicMetadataRepository implements TopicMetadataRepository {
     private ConcurrentMap<String, FluxTopic> topicMetadata = new ConcurrentHashMap<>();
@@ -23,8 +27,6 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
     private InMemoryTopicMetadataRepository() {
     }
 
-    // Bill Pugh Singleton -- loads the SingletonHelper and subsequently creates the InMemoryTopicMetadataRepository instance
-    // itself *only* when someone calls getInstance(). Avoids needing to do manual synchronization for multithreaded scenarios.
     private static class SingletonHelper {
         private static final InMemoryTopicMetadataRepository INSTANCE = new InMemoryTopicMetadataRepository();
     }
@@ -54,7 +56,7 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
 
     @Override
     public Set<String> getActiveTopics() {
-        return topicMetadata.keySet();
+        return Collections.unmodifiableSet(topicMetadata.keySet());
     }
 
     @Override

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -20,6 +20,18 @@ import java.util.concurrent.ConcurrentMap;
 public class InMemoryTopicMetadataRepository implements TopicMetadataRepository {
     private ConcurrentMap<String, FluxTopic> topicMetadata = new ConcurrentHashMap<>();
 
+    private InMemoryTopicMetadataRepository() {
+        throw new AssertionError("Can not instantiate InMemoryTopicMetadataRepository.");
+    }
+
+    private static class SingletonHolder {
+        private static final InMemoryTopicMetadataRepository INSTANCE = new InMemoryTopicMetadataRepository();
+    }
+
+    public static InMemoryTopicMetadataRepository getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
     @Override
     public void addNewTopic(String topicName, FluxTopic topic) {
         topicMetadata.put(topicName, topic);

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -21,15 +21,16 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
     private ConcurrentMap<String, FluxTopic> topicMetadata = new ConcurrentHashMap<>();
 
     private InMemoryTopicMetadataRepository() {
-        throw new AssertionError("Can not instantiate InMemoryTopicMetadataRepository.");
     }
 
-    private static class SingletonHolder {
+    // Bill Pugh Singleton -- loads the SingletonHelper and subsequently creates the InMemoryTopicMetadataRepository instance
+    // itself *only* when someone calls getInstance(). Avoids needing to do manual synchronization for multithreaded scenarios.
+    private static class SingletonHelper {
         private static final InMemoryTopicMetadataRepository INSTANCE = new InMemoryTopicMetadataRepository();
     }
 
     public static InMemoryTopicMetadataRepository getInstance() {
-        return SingletonHolder.INSTANCE;
+        return SingletonHelper.INSTANCE;
     }
 
     @Override
@@ -71,8 +72,8 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
         if (!topicMetadata.containsKey(topicName)) {
             throw new IllegalArgumentException("Topic " + topicName + " does not exist. Create it first or check for typos.");
         }
-        int startPartitionId = topicMetadata.get(topicName).getPartitions().get(0).getPartitionId();
-        int endPartitionId = topicMetadata.get(topicName).getPartitions().get(topicMetadata.size() - 1).getPartitionId();
+        int startPartitionId = topicMetadata.get(topicName).getPartitions().getFirst().getPartitionId();
+        int endPartitionId = topicMetadata.get(topicName).getPartitions().getLast().getPartitionId();
         return new IntRange(startPartitionId, endPartitionId);
     }
 }

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -1,0 +1,61 @@
+package metadata;
+
+import broker.Partition;
+import commons.FluxTopic;
+import commons.IntRange;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * NOTE: Apache Kafka itself uses a log-based approach to storing metadata, where its essentially its own topic
+ * with partitions, offsets, etc. It additionally comes with its own methods where you must make
+ * network requests to a broker to retrieve metadata.
+ *
+ * However, for simplicity reasons, we are (currently) implementing an in-memory approach to storing Topic metadata
+ * using the Repository pattern. Down the line we will refactor to more closely align with Kafka's implementation.
+ */
+public class InMemoryTopicMetadataRepository implements TopicMetadataRepository {
+    private ConcurrentMap<String, FluxTopic> topicMetadata = new ConcurrentHashMap<>();
+
+    @Override
+    public void addNewTopic(String topicName, FluxTopic topic) {
+        topicMetadata.put(topicName, topic);
+    }
+
+    @Override
+    public boolean deleteTopic(String topicName) {
+        if (topicMetadata.containsKey(topicName)) {
+            topicMetadata.remove(topicName);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Set<String> getActiveTopics() {
+        return topicMetadata.keySet();
+    }
+
+    @Override
+    public List<Partition> getPartitions(String topicName) {
+        if (!topicMetadata.containsKey(topicName)) {
+            throw new IllegalArgumentException("Topic " + topicName + " does not exist. Create it first or check for typos.");
+        }
+        return topicMetadata.get(topicName).getPartitions();
+    }
+
+    @Override
+    public IntRange getPartitionIdRangeForTopic(String topicName) {
+        // Because we're creating and adding Partitions sequentially in Broker#createTopics, we can assume that
+        // the first Partition in the list has the minimum ID
+        if (!topicMetadata.containsKey(topicName)) {
+            throw new IllegalArgumentException("Topic " + topicName + " does not exist. Create it first or check for typos.");
+        }
+        int startPartitionId = topicMetadata.get(topicName).getPartitions().get(0).getPartitionId();
+        int endPartitionId = topicMetadata.get(topicName).getPartitions().get(topicMetadata.size() - 1).getPartitionId();
+        return new IntRange(startPartitionId, endPartitionId);
+    }
+}

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -35,12 +35,17 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
     }
 
     @Override
+    public boolean topicExists(String topicName) {
+        return topicMetadata.containsKey(topicName);
+    }
+
+    @Override
     public Set<String> getActiveTopics() {
         return topicMetadata.keySet();
     }
 
     @Override
-    public List<Partition> getPartitions(String topicName) {
+    public List<Partition> getPartitionsFor(String topicName) {
         if (!topicMetadata.containsKey(topicName)) {
             throw new IllegalArgumentException("Topic " + topicName + " does not exist. Create it first or check for typos.");
         }

--- a/src/main/java/metadata/TopicMetadataRepository.java
+++ b/src/main/java/metadata/TopicMetadataRepository.java
@@ -1,0 +1,16 @@
+package metadata;
+
+import broker.Partition;
+import commons.FluxTopic;
+import commons.IntRange;
+
+import java.util.List;
+import java.util.Set;
+
+public interface TopicMetadataRepository {
+    void addNewTopic(String topicName, FluxTopic topic);
+    boolean deleteTopic(String topicName);
+    Set<String> getActiveTopics();
+    List<Partition> getPartitions(String topicName);
+    IntRange getPartitionIdRangeForTopic(String topicName);
+}

--- a/src/main/java/metadata/TopicMetadataRepository.java
+++ b/src/main/java/metadata/TopicMetadataRepository.java
@@ -10,7 +10,8 @@ import java.util.Set;
 public interface TopicMetadataRepository {
     void addNewTopic(String topicName, FluxTopic topic);
     boolean deleteTopic(String topicName);
+    boolean topicExists(String topicName);
     Set<String> getActiveTopics();
-    List<Partition> getPartitions(String topicName);
+    List<Partition> getPartitionsFor(String topicName);
     IntRange getPartitionIdRangeForTopic(String topicName);
 }

--- a/src/main/java/producer/IntermediaryRecord.java
+++ b/src/main/java/producer/IntermediaryRecord.java
@@ -1,0 +1,12 @@
+package producer;
+
+/**
+ * Represents an intermediary form of our records as it gets passed through the system.
+ *
+ * This form makes it easier to track metadata (target partition ID) for newly serialized records without
+ * having to prematurely de-serialize them once they reach the broker just to extract said metadata.
+ * @param targetPartition id of partition to send this record to
+ * @param data the record in serialized form
+ */
+public record IntermediaryRecord(int targetPartition, byte[] data) {
+}

--- a/src/main/java/producer/MurmurHash2.java
+++ b/src/main/java/producer/MurmurHash2.java
@@ -74,4 +74,16 @@ public final class MurmurHash2 {
         int positiveHash = hash & 0x7fffffff;
         return positiveHash % numPartitions;
     }
+
+    public static int selectPartitionWithinRange(String key, int min, int max) {
+        if (key == null || key.isEmpty()) {
+            return min;
+        }
+        int hash = MurmurHash2.hash(key);
+        // Turn the hash into a positive number.
+        // The & 0x7fffffff operation is a faster way of doing Math.abs()
+        // that also handles Integer.MIN_VALUE correctly.
+        int positiveHash = hash & 0x7fffffff;
+        return min + (positiveHash % max - min + 1);
+    }
 }

--- a/src/main/java/producer/MurmurHash2.java
+++ b/src/main/java/producer/MurmurHash2.java
@@ -57,33 +57,4 @@ public final class MurmurHash2 {
         h ^= h >>> 15;
         return h;
     }
-
-    /**
-     * Standardized partition selection utility.
-     * If key is null/empty, returns 0 (default partition).
-     * Otherwise, returns MurmurHash2(key) % numPartitions.
-     */
-    public static int selectPartition(String key, int numPartitions) {
-        if (key == null || key.isEmpty()) {
-            return 0;
-        }
-        int hash = MurmurHash2.hash(key);
-        // Turn the hash into a positive number.
-        // The & 0x7fffffff operation is a faster way of doing Math.abs()
-        // that also handles Integer.MIN_VALUE correctly.
-        int positiveHash = hash & 0x7fffffff;
-        return positiveHash % numPartitions;
-    }
-
-    public static int selectPartitionWithinRange(String key, int min, int max) {
-        if (key == null || key.isEmpty()) {
-            return min;
-        }
-        int hash = MurmurHash2.hash(key);
-        // Turn the hash into a positive number.
-        // The & 0x7fffffff operation is a faster way of doing Math.abs()
-        // that also handles Integer.MIN_VALUE correctly.
-        int positiveHash = hash & 0x7fffffff;
-        return min + (positiveHash % max - min + 1);
-    }
 }

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -1,16 +1,12 @@
 package producer;
 
-import commons.IntRange;
 import commons.utils.PartitionSelector;
-import exceptions.InvalidPartitionException;
 import metadata.InMemoryTopicMetadataRepository;
-import metadata.TopicMetadataRepository;
 import org.tinylog.Logger;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class RecordAccumulator {
     static private final int DEFAULT_BATCH_SIZE = 10_240; // 10 KB
@@ -19,20 +15,16 @@ public class RecordAccumulator {
     private Map<Integer, RecordBatch> partitionBatches; // Per-partition batches
     private final int numPartitions;
 
-    private TopicMetadataRepository topicMetadata;
-
     public RecordAccumulator(int numPartitions) {
         this.batchSize = validateBatchSize(DEFAULT_BATCH_SIZE);
         this.partitionBatches = new HashMap<>();
         this.numPartitions = numPartitions;
-        this.topicMetadata = new InMemoryTopicMetadataRepository();
     }
 
     public RecordAccumulator(int batchSize, int numPartitions) {
         this.batchSize = validateBatchSize(batchSize);
         this.partitionBatches = new HashMap<>();
         this.numPartitions = numPartitions;
-        this.topicMetadata = new InMemoryTopicMetadataRepository();
     }
 
     public RecordBatch createBatch(int partition, long baseOffset) {
@@ -58,7 +50,7 @@ public class RecordAccumulator {
                 serializedRecord, String.class, String.class);
 
         return PartitionSelector.getPartitionNumberForRecord(
-                topicMetadata,
+                InMemoryTopicMetadataRepository.getInstance(),
                 record.getPartitionNumber(),
                 record.getKey(),
                 record.getTopic(),

--- a/src/main/proto/publish.proto
+++ b/src/main/proto/publish.proto
@@ -10,7 +10,12 @@ service PublishToBroker {
 }
 
 message PublishDataToBrokerRequest {
-  repeated bytes data = 1;
+  repeated Record records = 1;
+}
+
+message Record {
+  int32 targetPartition = 1;
+  bytes data = 2;
 }
 
 message BrokerToPublisherAck {


### PR DESCRIPTION
Mostly closes #68*

- Created `FluxTopic` - logical grouping of related partitions
- Handles topic creation request via the `FluxAdmin` (validation + actual creation happens in `Broker`)
- Partition selection for records now handles topics + is now encapsulated in a utility class (`PartitionSelector`)
- Implemented `IntermediaryRecord` to prevent premature deserialization of producer records when trying to extract a target partition
- Metadata for Topics and Brokers are now stored in Repository singletons for easier access to metadata
    - these are both temporary/convenient solutions until we implement something more kafka-like
- Created custom exceptions for invalid topics and partitions

*The consumer side of topics, where consumers can subscribe + fetch messages from a topic has not yet been implemented, but should be addressed in coming PRs