### PR TITLE
77 consumer group coordinator

### DIFF
--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -10,3 +10,8 @@ enum Status {
   FAILURE = 3; // if u want to just be general
   READ_COMPLETION = 4;
 }
+
+// Shared timestamp type
+message Timestamp {
+  int64 milliseconds = 1;
+}

--- a/src/main/proto/consumer_group.proto
+++ b/src/main/proto/consumer_group.proto
@@ -5,64 +5,90 @@ import "common.proto";
 option java_package = "proto";
 option java_multiple_files = true;
 
-service ConsumerGroupService {
+service GroupCoordinatorService {
   rpc JoinGroup(JoinGroupRequest) returns (JoinGroupResponse);
   rpc SyncGroup(SyncGroupRequest) returns (SyncGroupResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
   rpc LeaveGroup(LeaveGroupRequest) returns (LeaveGroupResponse);
 }
 
-message MemberMetadata {
-  string member_id = 1;
-  repeated string topics = 2;
-  bytes userData = 3;
+enum GroupStatus {
+  GROUP_OK = 0;
+
+  // Membership states
+  NOT_GROUP_LEADER = 1;
+  MEMBER_NOT_FOUND = 2;
+  MEMBER_ID_REQUIRED = 3;
+  STALE_MEMBER_GENERATION = 4;
+
+  // Group states
+  GROUP_REBALANCING = 5;
+  GROUP_LOADING = 6;
+  GROUP_NOT_FOUND = 7;
+  GROUP_COORDINATOR_CHANGED = 8;
+
+  // Protocol errors
+  INCOMPATIBLE_PROTOCOL = 9;
+  INVALID_SESSION_TIMEOUT = 10;
+
+  // Authorization
+  GROUP_AUTH_FAILED = 11;
 }
 
-message MemberAssignment {
+message ProtocolMetadata {
+  string name = 1; //[ "range", "roundrobin"]
+  bytes metadata = 2;
+}
+
+message MemberInfo {
   string member_id = 1;
-  bytes assignment = 2;
+  bytes metadata = 2;
+}
+
+message Assignment {
+  bytes assignment = 1;
 }
 
 message JoinGroupRequest {
   string group_id = 1;
   string member_id = 2;
   int32 session_timeout_ms = 3;
-  int32 rebalance_timeout_ms = 4;
-  repeated string protocols = 5; // [RANGE, ROUND_ROBIN]
-};
+  int32 rebalance_timeout_ms = 4; // Max time for all joins
+  repeated ProtocolMetadata protocols = 5;
+}
 message JoinGroupResponse {
-  Status status = 1;
-  string group_id = 2;
+  GroupStatus status = 1;
+  string member_id = 2;
   int32 generation_id = 3;
   string leader_id = 4;
-  string member_id = 5;
-  repeated MemberMetadata members = 6;
-};
+  string protocol = 5;
+  repeated MemberInfo members = 6; // Only sent to leader
+}
 
 message SyncGroupRequest {
   string group_id = 1;
   int32 generation_id = 2;
   string member_id = 3;
-  repeated MemberAssignment assignments = 4; // ONLY leader wil fill assignments.
-};
+  Assignment assignment = 4;  // Leader sends group assignments
+}
 message SyncGroupResponse {
-  Status status = 1;
-  bytes assignment = 2; // For each follower => its own assignment
-};
+  GroupStatus status = 1;
+  Assignment assignment = 2;  // Member-specific assignment
+}
 
 message HeartbeatRequest {
   string group_id = 1;
   string member_id = 2;
   int32 generation_id = 3;
-};
+}
 message HeartbeatResponse {
-  Status status = 1;
-};
+  GroupStatus status = 1;
+}
 
 message LeaveGroupRequest {
   string group_id = 1;
   string member_id = 2;
-};
+}
 message LeaveGroupResponse {
-  Status status = 1;
-};
+  GroupStatus status = 1;
+}

--- a/src/main/proto/consumer_group.proto
+++ b/src/main/proto/consumer_group.proto
@@ -52,7 +52,7 @@ message Assignment {
 message JoinGroupRequest {
   string group_id = 1;
   string member_id = 2;
-  int32 session_timeout_ms = 3;
+  int32 session_timeout_ms = 3; // heartbeat check
   int32 rebalance_timeout_ms = 4; // Max time for all joins
   repeated ProtocolMetadata protocols = 5;
 }

--- a/src/main/proto/consumer_group.proto
+++ b/src/main/proto/consumer_group.proto
@@ -8,19 +8,61 @@ option java_multiple_files = true;
 service ConsumerGroupService {
   rpc JoinGroup(JoinGroupRequest) returns (JoinGroupResponse);
   rpc SyncGroup(SyncGroupRequest) returns (SyncGroupResponse);
-  rpc HeartBeat(HeartBeatRequest) returns (HeartBeatResponse);
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
   rpc LeaveGroup(LeaveGroupRequest) returns (LeaveGroupResponse);
 }
 
+message MemberMetadata {
+  string member_id = 1;
+  repeated string topics = 2;
+  bytes userData = 3;
+}
 
-message JoinGroupRequest {};
-message JoinGroupResponse {};
+message MemberAssignment {
+  string member_id = 1;
+  bytes assignment = 2;
+}
 
-message SyncGroupRequest {};
-message SyncGroupResponse {};
+message JoinGroupRequest {
+  string group_id = 1;
+  string member_id = 2;
+  int32 session_timeout_ms = 3;
+  int32 rebalance_timeout_ms = 4;
+  repeated string protocols = 5; // [RANGE, ROUND_ROBIN]
+};
+message JoinGroupResponse {
+  Status status = 1;
+  string group_id = 2;
+  int32 generation_id = 3;
+  string leader_id = 4;
+  string member_id = 5;
+  repeated MemberMetadata members = 6;
+};
 
-message HeartBeatRequest {};
-message HeartBeatResponse {};
+message SyncGroupRequest {
+  string group_id = 1;
+  int32 generation_id = 2;
+  string member_id = 3;
+  repeated MemberAssignment assignments = 4; // ONLY leader wil fill assignments.
+};
+message SyncGroupResponse {
+  Status status = 1;
+  bytes assignment = 2; // For each follower => its own assignment
+};
 
-message LeaveGroupRequest {};
-message LeaveGroupResponse {};
+message HeartbeatRequest {
+  string group_id = 1;
+  string member_id = 2;
+  int32 generation_id = 3;
+};
+message HeartbeatResponse {
+  Status status = 1;
+};
+
+message LeaveGroupRequest {
+  string group_id = 1;
+  string member_id = 2;
+};
+message LeaveGroupResponse {
+  Status status = 1;
+};

--- a/src/main/proto/consumer_group.proto
+++ b/src/main/proto/consumer_group.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+import "common.proto";
+
+option java_package = "proto";
+option java_multiple_files = true;
+
+service ConsumerGroupService {
+  rpc JoinGroup(JoinGroupRequest) returns (JoinGroupResponse);
+  rpc SyncGroup(SyncGroupRequest) returns (SyncGroupResponse);
+  rpc HeartBeat(HeartBeatRequest) returns (HeartBeatResponse);
+  rpc LeaveGroup(LeaveGroupRequest) returns (LeaveGroupResponse);
+}
+
+
+message JoinGroupRequest {};
+message JoinGroupResponse {};
+
+message SyncGroupRequest {};
+message SyncGroupResponse {};
+
+message HeartBeatRequest {};
+message HeartBeatResponse {};
+
+message LeaveGroupRequest {};
+message LeaveGroupResponse {};

--- a/src/main/proto/offset.proto
+++ b/src/main/proto/offset.proto
@@ -1,0 +1,10 @@
+service OffsetService {
+  rpc CommitOffsets(OffsetCommitRequest) returns (OffsetCommitResponse);
+  rpc FetchOffsets(FetchOffsetsRequest) returns (FetchOffsetsResponse);
+}
+
+message OffsetCommitRequest {};
+message OffsetCommitResponse {};
+
+message FetchOffsetsRequest {};
+message FetchOffsetsResponse {};

--- a/src/main/proto/offset.proto
+++ b/src/main/proto/offset.proto
@@ -1,10 +1,66 @@
+syntax = "proto3";
+
+import "common.proto";
+
+option java_package = "proto";
+option java_multiple_files = true;
+
 service OffsetService {
   rpc CommitOffsets(OffsetCommitRequest) returns (OffsetCommitResponse);
   rpc FetchOffsets(FetchOffsetsRequest) returns (FetchOffsetsResponse);
 }
 
-message OffsetCommitRequest {};
-message OffsetCommitResponse {};
+enum OffsetStatus {
+  OFFSET_OK = 0;
+  OFFSET_COMMIT_DISABLED = 1;
+  OFFSET_LOAD_FAILED = 2;
+  OFFSET_NOT_FOUND = 3;
+  OFFSET_STALE = 4; // TOO OLD!
+  OFFSET_INVALID = 5; // negative offsets
+  OFFSET_AUTH_FAILED = 6;
+}
 
-message FetchOffsetsRequest {};
-message FetchOffsetsResponse {};
+message TopicPartition {
+  string topic = 1;
+  int32 partition = 2;
+}
+
+message OffsetCommit {
+  TopicPartition topic_partition = 1;
+  int64 offset = 2;
+  bytes metadata = 3;
+  int64 commit_timestamp = 4;  // Client-side timestamp
+}
+
+message OffsetCommitRequest {
+  string group_id = 1;
+  int32 generation_id = 2;
+  string member_id = 3;
+  int64 retention_time_ms = 4;
+  repeated OffsetCommit commits = 5;
+}
+
+message OffsetCommitResponse {
+  OffsetStatus status = 1;
+  map<string, OffsetStatus> partition_errors = 2;  // Key: "topic:partition"
+}
+
+message OffsetFetch {
+  TopicPartition topic_partition = 1;
+  int64 offset = 2;
+  bytes metadata = 3;
+  int64 commit_timestamp = 4;
+  int64 expire_timestamp = 5;  // When this offset will expire
+}
+
+message FetchOffsetsRequest {
+  string group_id = 1;
+  repeated TopicPartition partitions = 2;
+  bool require_stable = 3;
+}
+
+message FetchOffsetsResponse {
+  OffsetStatus status = 1;
+  repeated OffsetFetch offsets = 2;
+  map<string, OffsetStatus> partition_errors = 3;
+}


### PR DESCRIPTION
## Description
- Initial phase/setup of Consumer Group Operations. 
- I heavily recommend looking at the docs, I updated it and labeled it as "Consumer Groups". 
- I'll give a quick rundown below

## Quick Reference (Look at docs for deeper dive)


### JoinGroup
 When a consumer instance wants to join (or rejoin) a consumer group, it sends a JoinGroup request to the group coordinator, including its group.id, an empty or previous memberId, and its topic subscription metadata. The coordinator then collects these requests from all group members, elects one as the group leader, and returns to each member a unique memberId and, for the leader, the full list of members and their subscriptions 

### SyncGroup
 After the leader receives the member list in its JoinGroup response, it computes a partition-to-consumer assignment using the configured assignor and issues a SyncGroup request (with its memberId and the proposed assignment) back to the coordinator. All other members also send SyncGroup with just their memberId. Once the coordinator has received a SyncGroup from each member, it responds with each member’s final partition assignment, marking the group as “Stable” and incrementing the generation ID 

### Heartbeat
To maintain liveness and avoid unnecessary rebalances, each consumer must periodically send a Heartbeat request to the coordinator (at an interval ≤ heartbeat.interval.ms). The coordinator uses these heartbeats to track which consumers are alive; missing heartbeats beyond the configured session.timeout.ms causes the coordinator to deem the member dead and trigger a rebalance

### LeaveGroup
When a consumer cleanly shuts down or loses interest in consuming, it sends a LeaveGroup request. The coordinator immediately removes that member from the group metadata and initiates a rebalance so the remaining consumers can evenly redistribute the partitions previously assigned to the leaving member


## Quick Notes
- I haven't done a deep dive on `OffsetCommit` yet but on the `comsumer_group.proto` I validated and confident its the  proper way to do it.