### PR TITLE
90: Change Partition IDs to start from 0 instead of 1

### DIFF
--- a/src/main/java/commons/utils/PartitionSelector.java
+++ b/src/main/java/commons/utils/PartitionSelector.java
@@ -66,7 +66,7 @@ public class PartitionSelector {
                 return roundRobinCounter.getAndIncrement() % numPartitions;
             }
         } else { // Validate partition number
-            if (1 <= partitionNumber && partitionNumber <= numPartitions) {
+            if (0 <= partitionNumber && partitionNumber < numPartitions) {
                 return partitionNumber;
             } else {
                 return roundRobinCounter.getAndIncrement() % numPartitions;

--- a/src/main/java/server/internal/Broker.java
+++ b/src/main/java/server/internal/Broker.java
@@ -21,7 +21,7 @@ public class Broker {
     private int port; // ex: port 8080
     private int numPartitions;
     private List<Partition> partitions;
-    private int partitionIdCounter = 1;
+    private int partitionIdCounter = 0;
     private AtomicInteger roundRobinCounter = new AtomicInteger(0);
     private final PartitionWriteManager writeManager;
 
@@ -91,8 +91,8 @@ public class Broker {
     }
 
     public int produceSingleMessage(int targetPartitionId, byte[] record) throws IOException {
-        // Note: Partition IDs are NOT 0-indexed
-        Partition targetPartition = partitions.get(targetPartitionId - 1);
+        // Note: Partition IDs are 0-indexed now
+        Partition targetPartition = partitions.get(targetPartitionId);
 
         // Use the write manager for thread-safe write operation
         return writeManager.writeToPartition(targetPartition, record);
@@ -131,19 +131,20 @@ public class Broker {
     public Message consumeMessage(int startingOffset) throws IOException {
         // Default to partition 0 for backward compatibility
         // TODO: Replace placeholder partitionID
-        return consumeMessage(1, startingOffset);
+        return consumeMessage(0, startingOffset);
     }
 
     /**
      * Consume a message from a specific partition at the given offset
      */
     public Message consumeMessage(int partitionId, int startingOffset) throws IOException {
-        if (partitionId < 1 || partitionId > numPartitions) {
+        if (partitionId < 0 || partitionId >= numPartitions) {
             throw new IllegalArgumentException(
-                    "Invalid partition ID: %d. Valid range: 1-%d".formatted(partitionId, numPartitions));
+                // since partition IDs are 0-indexed now we take the number of partitions and subtract 1
+                    "Invalid partition ID: %d. Valid range: 0-%d".formatted(partitionId, numPartitions - 1));
         }
 
-        Partition targetPartition = partitions.get(partitionId - 1);
+        Partition targetPartition = partitions.get(partitionId);
         return targetPartition.getRecordAtOffset(startingOffset);
     }
 
@@ -167,11 +168,11 @@ public class Broker {
      * Get a specific partition by ID
      */
     public Partition getPartition(int partitionId) {
-        if (partitionId < 1 || partitionId > numPartitions) {
+        if (partitionId < 0 || partitionId >= numPartitions) {
             throw new IllegalArgumentException(
-                    "Invalid partition ID: %d. Valid range: 1-%d".formatted(partitionId, numPartitions));
+                    "Invalid partition ID: %d. Valid range: 0-%d".formatted(partitionId, numPartitions - 1));
         }
-        return partitions.get(partitionId - 1);
+        return partitions.get(partitionId);
     }
 
     /**

--- a/src/test/java/broker/FluxParallelProducerTest.java
+++ b/src/test/java/broker/FluxParallelProducerTest.java
@@ -62,7 +62,7 @@ public class FluxParallelProducerTest {
         
         // Create topic with partitions
         List<Partition> partitions = new ArrayList<>();
-        for (int i = 1; i <= NUM_PARTITIONS; i++) {
+        for (int i = 0; i < NUM_PARTITIONS; i++) {
             partitions.add(broker.getPartition(i));
         }
         FluxTopic testTopic = new FluxTopic(TEST_TOPIC, partitions, 1);
@@ -144,7 +144,7 @@ public class FluxParallelProducerTest {
         
         // Verify messages were received by the broker
         int totalMessages = 0;
-        for (int i = 1; i <= NUM_PARTITIONS; i++) {
+        for (int i = 0; i < NUM_PARTITIONS; i++) {
             int count = broker.getPartition(i).getCurrentOffset();
             totalMessages += count;
             Logger.info("Partition {} received {} messages", i, count);

--- a/src/test/java/consumer/ConsumerRecordTest.java
+++ b/src/test/java/consumer/ConsumerRecordTest.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public class ConsumerRecordTest {
     String topic = "Test Topic";
-    int partition = 1;
+    int partition = 0;
     long offset = 1;
     long timestamp = 1704067200;
     String key = "key";


### PR DESCRIPTION
## Summary
- Changed partition IDs from 1-based to 0-based indexing to align with Kafka's convention
- Eliminated offset calculations when accessing partitions
- Updated all validation logic and tests to reflect the new indexing scheme

## Changes Made
1. **Broker.java**
   - Changed `partitionIdCounter` initialization from 1 to 0
   - Removed `partitionId - 1` offset calculations in `produceSingleMessage()`, `consumeMessage()`, and `getPartition()`
   - Updated validation ranges from `1 <= partitionId <= numPartitions` to `0 <= partitionId < numPartitions`
   - Updated default partition ID in `consumeMessage()` from 1 to 0

2. **PartitionSelector.java**
   - Updated validation range in `getPartitionNumWhenTopicDoesNotExist()` to use 0-based indexing

3. **Test Updates**
   - ConsumerRecordTest: Changed test partition from 1 to 0
   - FluxParallelProducerTest: Updated loops to iterate from 0 to NUM_PARTITIONS

## Related Issue
Closes #90