### PR TITLE
Initial Controller Node Infrastructure + Broker Registration/Decommission

### DIFF
--- a/src/main/java/grpc/BrokerServer.java
+++ b/src/main/java/grpc/BrokerServer.java
@@ -14,14 +14,14 @@ public class BrokerServer {
 
     private Server server;
     private final Broker broker;
+    private final ExecutorService executor;
 
     public BrokerServer(Broker broker) {
+        executor = Executors.newFixedThreadPool(6);
         this.broker = broker;
     }
 
     public void start(int port) throws IOException {
-
-        ExecutorService executor = Executors.newFixedThreadPool(6);
         server = Grpc.newServerBuilderForPort(port, InsecureServerCredentials.create())
                 .executor(executor)
                 .addService(new ProducerServiceImpl(this.broker))
@@ -59,6 +59,7 @@ public class BrokerServer {
         if (server != null) {
             server.shutdown();
         }
+        executor.shutdown();
     }
 
     public void blockUntilShutdown() throws InterruptedException {
@@ -66,5 +67,4 @@ public class BrokerServer {
             server.awaitTermination();
         }
     }
-
 }

--- a/src/main/java/grpc/BrokerServer.java
+++ b/src/main/java/grpc/BrokerServer.java
@@ -1,6 +1,7 @@
 package grpc;
 
 import grpc.services.*;
+import org.tinylog.Logger;
 import server.internal.Broker;
 import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
@@ -19,6 +20,7 @@ public class BrokerServer {
     public BrokerServer(Broker broker) {
         executor = Executors.newFixedThreadPool(6);
         this.broker = broker;
+        this.broker.registerShutdownCallback(() -> stop());
     }
 
     public void start(int port) throws IOException {
@@ -58,6 +60,12 @@ public class BrokerServer {
     public void stop() throws InterruptedException {
         if (server != null) {
             server.shutdown();
+            Logger.info("Server @ %s:%d with broker ID = %s has shut down."
+                    .formatted(broker.getHost(),
+                            broker.getPort(),
+                            broker.getBrokerId()
+                    )
+            );
         }
         executor.shutdown();
     }

--- a/src/main/java/grpc/BrokerServer.java
+++ b/src/main/java/grpc/BrokerServer.java
@@ -1,10 +1,7 @@
 package grpc;
 
+import grpc.services.*;
 import server.internal.Broker;
-import grpc.services.ConsumerServiceImpl;
-import grpc.services.CreateTopicsServiceImpl;
-import grpc.services.MetadataServiceImpl;
-import grpc.services.ProducerServiceImpl;
 import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
@@ -31,6 +28,7 @@ public class BrokerServer {
                 .addService(new ConsumerServiceImpl(this.broker))
                 .addService(new CreateTopicsServiceImpl(this.broker))
                 .addService(new MetadataServiceImpl(this.broker))
+                .addService(new ControllerServiceImpl(this.broker))
                 .build()
                 .start();
 

--- a/src/main/java/grpc/services/ControllerServiceImpl.java
+++ b/src/main/java/grpc/services/ControllerServiceImpl.java
@@ -1,0 +1,47 @@
+package grpc.services;
+
+import io.grpc.stub.StreamObserver;
+import org.tinylog.Logger;
+import proto.BrokerRegistrationRequest;
+import proto.BrokerRegistrationResult;
+import proto.ControllerServiceGrpc;
+import proto.Status;
+import server.internal.Broker;
+
+public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServiceImplBase {
+    Broker broker;
+
+    public ControllerServiceImpl(Broker broker) {
+        this.broker  = broker;
+    }
+
+    @Override
+    public void registerBroker(BrokerRegistrationRequest req, StreamObserver<BrokerRegistrationResult> responseObserver) {
+        // Non-controller nodes should not be returning a response for Broker registration.
+        if (!broker.isActiveController()) {
+            return;
+        }
+
+        BrokerRegistrationResult response = BrokerRegistrationResult
+                .newBuilder()
+                .setAcknowledgement("ACK: Controller {broker=%s, address=%s:%d} received BrokerRegistrationRequest from {node=%s, address=%s:%d}".formatted(
+                        this.broker.getBrokerId(),
+                        this.broker.getHost(),
+                        this.broker.getPort(),
+                        req.getBrokerId(),
+                        req.getBrokerHost(),
+                        req.getBrokerPort()
+                        )
+                )
+                .setStatus(Status.SUCCESS)
+                .build();
+
+        broker.getFollowerNodeEndpoints()
+                .put(req.getBrokerId(), "%s:%d".formatted(req.getBrokerHost(), req.getBrokerPort()));
+
+        Logger.info("Current follower nodes: " + broker.getFollowerNodeEndpoints().toString());
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/java/grpc/services/ControllerServiceImpl.java
+++ b/src/main/java/grpc/services/ControllerServiceImpl.java
@@ -46,13 +46,13 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void unregisterBroker(UnregisterBrokerRequest req, StreamObserver<UnregisterBrokerResult> responseObserver) {
+    public void decommissionBroker(DecommissionBrokerRequest req, StreamObserver<DecommissionBrokerResult> responseObserver) {
         if (!broker.isActiveController()) {
             return;
         }
 
-        UnregisterBrokerResult response = UnregisterBrokerResult.newBuilder()
-                .setAcknowledgement("ACK: Controller {broker=%s, address=%s:%d} received UnregisterBrokerRequest from {node=%s}. Removing broker from followers."
+        DecommissionBrokerResult response = DecommissionBrokerResult.newBuilder()
+                .setAcknowledgement("ACK: Controller {broker=%s, address=%s:%d} received DecommissionBrokerRequest from {node=%s}. Removing this broker from followers and gracefully shutting it down."
                         .formatted(
                                 this.broker.getBrokerId(),
                                 this.broker.getHost(),
@@ -60,12 +60,12 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
                                 req.getBrokerId()
                         )
                 )
-                .setStatus(Status.SUCCESS)
+                .setStatus(Status.BROKER_SHUTDOWN_IN_PROGRESS)
                 .build();
 
         broker.getFollowerNodeEndpoints().remove(req.getBrokerId());
 
-        Logger.info("Removed follower node {node=%s} from this cluster with Controller {broker=%s, address=%s:%d}"
+        Logger.info("Removed follower node {node=%s} from this cluster with Controller {broker=%s, address=%s:%d}. Broker is clear to gracefully shutdown."
                 .formatted(
                         req.getBrokerId(),
                         this.broker.getBrokerId(),

--- a/src/main/java/server/internal/Broker.java
+++ b/src/main/java/server/internal/Broker.java
@@ -125,24 +125,26 @@ public class Broker implements Controller {
     }
 
     @Override
-    public void unregisterBroker() {
+    public void decommissionBroker() {
         if (controllerEndpoint.isEmpty()) {
-            Logger.warn("Cannot unregister broker that is not part of any cluster.");
+            Logger.warn("Cannot decommission broker that is not part of any cluster.");
             return;
         }
 
         if (!isActiveController) {
-            UnregisterBrokerRequest request = UnregisterBrokerRequest
+            DecommissionBrokerRequest request = DecommissionBrokerRequest
                     .newBuilder()
                     .setBrokerId(this.brokerId)
                     .build();
 
-            Logger.info(brokerId + " @ " + host + ":" + port + " SENDING OVER UNREGISTER BROKER REQUEST TO CONTROLLER @ " + controllerEndpoint);
-            ListenableFuture<UnregisterBrokerResult> response = futureStub.unregisterBroker(request);
-            Futures.addCallback(response, new FutureCallback<UnregisterBrokerResult>() {
+            Logger.info(brokerId + " @ " + host + ":" + port + " SENDING OVER DECOMMISSION BROKER REQUEST TO CONTROLLER @ " + controllerEndpoint);
+            ListenableFuture<DecommissionBrokerResult> response = futureStub.decommissionBroker(request);
+            Futures.addCallback(response, new FutureCallback<DecommissionBrokerResult>() {
                 @Override
-                public void onSuccess(UnregisterBrokerResult result) {
+                public void onSuccess(DecommissionBrokerResult result) {
                     Logger.info(result.getAcknowledgement());
+
+                    // TODO: Broker must now gracefully shutdown upon successful ack from controller
                 }
 
                 @Override

--- a/src/main/java/server/internal/Controller.java
+++ b/src/main/java/server/internal/Controller.java
@@ -16,6 +16,6 @@ import java.util.Collection;
 public interface Controller {
     void createTopics(Collection<Topic> topics) throws IOException;
     void registerBroker();
-    void unregisterBroker(String brokerId);
+    void unregisterBroker();
     void processBrokerHeartbeat(); // TODO: Update params when broker heartbeat ticket is being worked on
 }

--- a/src/main/java/server/internal/Controller.java
+++ b/src/main/java/server/internal/Controller.java
@@ -16,6 +16,6 @@ import java.util.Collection;
 public interface Controller {
     void createTopics(Collection<Topic> topics) throws IOException;
     void registerBroker();
-    void unregisterBroker();
+    void decommissionBroker();
     void processBrokerHeartbeat(); // TODO: Update params when broker heartbeat ticket is being worked on
 }

--- a/src/main/java/server/internal/Controller.java
+++ b/src/main/java/server/internal/Controller.java
@@ -15,7 +15,7 @@ import java.util.Collection;
  */
 public interface Controller {
     void createTopics(Collection<Topic> topics) throws IOException;
-    void registerBroker(String brokerId, String host, String port);
+    void registerBroker();
     void unregisterBroker(String brokerId);
     void processBrokerHeartbeat(); // TODO: Update params when broker heartbeat ticket is being worked on
 }

--- a/src/main/java/server/internal/Controller.java
+++ b/src/main/java/server/internal/Controller.java
@@ -1,0 +1,21 @@
+package server.internal;
+
+import proto.Topic;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * The Controller is a special broker within a cluster that acts as the "leader" of the cluster.
+ * It is responsible for handling special tasks such as managing/propagating metadata, topic lifestyle,
+ * distributing partitions, broker liveness, registration, and more.
+ *
+ * All brokers will implement this interface, however the extra functionality given by this interface
+ * will not be "activated" unless that broker is designated as the controller.
+ */
+public interface Controller {
+    void createTopics(Collection<Topic> topics) throws IOException;
+    void registerBroker(String brokerId, String host, String port);
+    void unregisterBroker(String brokerId);
+    void processBrokerHeartbeat(); // TODO: Update params when broker heartbeat ticket is being worked on
+}

--- a/src/main/java/server/internal/ShutdownCallback.java
+++ b/src/main/java/server/internal/ShutdownCallback.java
@@ -1,0 +1,9 @@
+package server.internal;
+
+/**
+ * Functional interface used to shutdown the Broker server in cases of decommission requests.
+ * Must match name of the stop method in BrokerServer in order to be implemented via lambda/method reference
+ */
+public interface ShutdownCallback {
+    void stop() throws InterruptedException;
+}

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -9,6 +9,7 @@ enum Status {
   PERMANENT_FAILURE = 2;
   FAILURE = 3; // if u want to just be general
   READ_COMPLETION = 4;
+  BROKER_SHUTDOWN_IN_PROGRESS = 5;
 }
 
 // Shared timestamp type

--- a/src/main/proto/controller.proto
+++ b/src/main/proto/controller.proto
@@ -7,6 +7,7 @@ option java_multiple_files = true;
 
 service ControllerService {
   rpc RegisterBroker(BrokerRegistrationRequest) returns (BrokerRegistrationResult);
+  rpc UnregisterBroker(UnregisterBrokerRequest) returns (UnregisterBrokerResult);
 }
 
 message BrokerRegistrationRequest {
@@ -16,6 +17,15 @@ message BrokerRegistrationRequest {
 }
 
 message BrokerRegistrationResult {
+  string acknowledgement = 1;
+  Status status = 2;
+}
+
+message UnregisterBrokerRequest {
+  string broker_id = 1;
+}
+
+message UnregisterBrokerResult {
   string acknowledgement = 1;
   Status status = 2;
 }

--- a/src/main/proto/controller.proto
+++ b/src/main/proto/controller.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+import "common.proto";
+
+option java_package = "proto";
+option java_multiple_files = true;
+
+service ControllerService {
+  rpc RegisterBroker(BrokerRegistrationRequest) returns (BrokerRegistrationResult);
+}
+
+message BrokerRegistrationRequest {
+  string broker_id = 1;
+  string broker_host = 2;
+  uint32 broker_port = 3;
+}
+
+message BrokerRegistrationResult {
+  string acknowledgement = 1;
+  Status status = 2;
+}

--- a/src/main/proto/controller.proto
+++ b/src/main/proto/controller.proto
@@ -7,7 +7,7 @@ option java_multiple_files = true;
 
 service ControllerService {
   rpc RegisterBroker(BrokerRegistrationRequest) returns (BrokerRegistrationResult);
-  rpc UnregisterBroker(UnregisterBrokerRequest) returns (UnregisterBrokerResult);
+  rpc DecommissionBroker(DecommissionBrokerRequest) returns (DecommissionBrokerResult);
 }
 
 message BrokerRegistrationRequest {
@@ -21,11 +21,12 @@ message BrokerRegistrationResult {
   Status status = 2;
 }
 
-message UnregisterBrokerRequest {
+message DecommissionBrokerRequest {
   string broker_id = 1;
+  // TODO: Might need more fields here, but wont know until later tickets get implemented first
 }
 
-message UnregisterBrokerResult {
+message DecommissionBrokerResult {
   string acknowledgement = 1;
   Status status = 2;
 }

--- a/src/test/java/broker/BrokerTest.java
+++ b/src/test/java/broker/BrokerTest.java
@@ -1,5 +1,6 @@
 package broker;
 
+import grpc.BrokerServer;
 import org.junit.jupiter.api.Test;
 import producer.RecordBatch;
 import server.internal.Broker;
@@ -20,5 +21,13 @@ public class BrokerTest {
         batch.append(new byte[]{90, 3, 2, 0, 102, 12, 34, 123, 93});
 
         broker.produceMessages(batch);
+    }
+
+    @Test
+    public void brokerShutdownTest() throws IOException {
+        Broker broker = new Broker("broker-1", "localhost", 8080);
+        BrokerServer server = new BrokerServer(broker);
+        server.start(8080);
+        broker.triggerManualBrokerShutdown();
     }
 }


### PR DESCRIPTION
Closes #91 

Changes:
- Created Controller RPC services + a Controller interface that all brokers implement by default
    - All brokers can make requests but only the controller node can return responses
- Controller node maintains its own channel and list of follower node addresses/endpoints for communication  
- Upon cluster initialization and startup, the very first broker gets selected as the controller node and all other brokers make `BrokerRegistrationRequests` to said controller in order to be part of the cluster
- Brokers can also decommission themselves now, essentially performing a graceful shutdown via a shutdown callback. Brokers must send `DecommissionBrokerRequest` to controller first to initiate this process