### PR TITLE
Fix unique partition IDs per topic

### DIFF
--- a/src/main/java/grpc/services/ConsumerServiceImpl.java
+++ b/src/main/java/grpc/services/ConsumerServiceImpl.java
@@ -18,7 +18,11 @@ public class ConsumerServiceImpl extends ConsumerServiceGrpc.ConsumerServiceImpl
         FetchMessageResponse.Builder responseBuilder = FetchMessageResponse.newBuilder();
         int nextOffset = req.getStartingOffset() + 1;
         try {
-            Message msg = this.broker.consumeMessage(req.getPartitionId(), req.getStartingOffset());
+            String topic = req.getTopic();
+            if (topic == null || topic.isEmpty()) {
+                throw new IllegalArgumentException("Topic name is required");
+            }
+            Message msg = this.broker.consumeMessage(topic, req.getPartitionId(), req.getStartingOffset());
             if (msg != null) {
                 responseBuilder
                         .setMessage(msg)

--- a/src/main/java/grpc/services/ProducerServiceImpl.java
+++ b/src/main/java/grpc/services/ProducerServiceImpl.java
@@ -25,11 +25,17 @@ public class ProducerServiceImpl extends PublishToBrokerGrpc.PublishToBrokerImpl
         List<IntermediaryRecord> records = req
                 .getRecordsList()
                 .stream()
-                .map(record -> new IntermediaryRecord(
-                                record.getTargetPartition(),
-                                record.getData().toByteArray()
-                        )
-                )
+                .map(record -> {
+                    String topic = record.getTopic();
+                    if (topic == null || topic.isEmpty()) {
+                        throw new IllegalArgumentException("Topic name is required for all records");
+                    }
+                    return new IntermediaryRecord(
+                            topic,
+                            record.getTargetPartition(),
+                            record.getData().toByteArray()
+                    );
+                })
                 .toList();
 
         try {

--- a/src/main/java/metadata/InMemoryTopicMetadataRepository.java
+++ b/src/main/java/metadata/InMemoryTopicMetadataRepository.java
@@ -77,4 +77,14 @@ public class InMemoryTopicMetadataRepository implements TopicMetadataRepository 
         int endPartitionId = topicMetadata.get(topicName).getPartitions().getLast().getPartitionId();
         return new IntRange(startPartitionId, endPartitionId);
     }
+    
+    /**
+     * Reset the repository by clearing all topic metadata.
+     * This is primarily for testing purposes.
+     * @return the singleton instance
+     */
+    public static InMemoryTopicMetadataRepository reset() {
+        getInstance().topicMetadata.clear();
+        return getInstance();
+    }
 }

--- a/src/main/java/producer/FluxProducer.java
+++ b/src/main/java/producer/FluxProducer.java
@@ -85,7 +85,11 @@ public class FluxProducer<K, V> implements Producer, MetadataListener {
         // Serialize data and convert to ByteString (gRPC only takes this form for byte data)
         byte[] serializedData = ProducerRecordCodec.serialize(record, key.getClass(), value.getClass());
 
-        buffer.add(new IntermediaryRecord(targetPartition, serializedData));
+        String topicName = record.getTopic();
+        if (topicName == null || topicName.isEmpty()) {
+            throw new IllegalArgumentException("Topic name is required for all records");
+        }
+        buffer.add(new IntermediaryRecord(topicName, targetPartition, serializedData));
         Logger.info("Record added to buffer.");
     }
 
@@ -115,6 +119,7 @@ public class FluxProducer<K, V> implements Producer, MetadataListener {
                                 .newBuilder()
                                 .setTargetPartition(r.targetPartition())
                                 .setData(ByteString.copyFrom(r.data()))
+                                .setTopic(r.topicName())
                                 .build()
                         )
                         .toList()

--- a/src/main/java/producer/IntermediaryRecord.java
+++ b/src/main/java/producer/IntermediaryRecord.java
@@ -5,8 +5,9 @@ package producer;
  *
  * This form makes it easier to track metadata (target partition ID) for newly serialized records without
  * having to prematurely de-serialize them once they reach the broker just to extract said metadata.
- * @param targetPartition id of partition to send this record to
+ * @param topicName name of the topic this record belongs to
+ * @param targetPartition id of partition to send this record to (within the topic)
  * @param data the record in serialized form
  */
-public record IntermediaryRecord(int targetPartition, byte[] data) {
+public record IntermediaryRecord(String topicName, int targetPartition, byte[] data) {
 }

--- a/src/test/java/broker/BrokerTest.java
+++ b/src/test/java/broker/BrokerTest.java
@@ -3,14 +3,25 @@ package broker;
 import org.junit.jupiter.api.Test;
 import producer.RecordBatch;
 import server.internal.Broker;
+import proto.Topic;
 
 import java.io.IOException;
+import java.util.List;
 
 public class BrokerTest {
 
     @Test
     public void produceMessagesTest() throws IOException {
         Broker broker = new Broker();
+        
+        // First create a topic
+        Topic testTopic = Topic.newBuilder()
+                .setTopicName("test-topic")
+                .setNumPartitions(3)
+                .setReplicationFactor(1)
+                .build();
+        broker.createTopics(List.of(testTopic));
+        
         RecordBatch batch = new RecordBatch();
 
         // append fake data
@@ -19,6 +30,6 @@ public class BrokerTest {
         batch.append(new byte[]{14, 6, 72, 1, 121, 31, 34, 123, 93});
         batch.append(new byte[]{90, 3, 2, 0, 102, 12, 34, 123, 93});
 
-        broker.produceMessages(batch);
+        broker.produceMessages("test-topic", batch);
     }
 }

--- a/src/test/java/broker/FluxParallelProducerTest.java
+++ b/src/test/java/broker/FluxParallelProducerTest.java
@@ -60,13 +60,13 @@ public class FluxParallelProducerTest {
         // Wait for server to start
         Thread.sleep(2000);
         
-        // Create topic with partitions
-        List<Partition> partitions = new ArrayList<>();
-        for (int i = 0; i < NUM_PARTITIONS; i++) {
-            partitions.add(broker.getPartition(i));
-        }
-        FluxTopic testTopic = new FluxTopic(TEST_TOPIC, partitions, 1);
-        InMemoryTopicMetadataRepository.getInstance().addNewTopic(TEST_TOPIC, testTopic);
+        // Create topic using proper API
+        proto.Topic topic = proto.Topic.newBuilder()
+                .setTopicName(TEST_TOPIC)
+                .setNumPartitions(NUM_PARTITIONS)
+                .setReplicationFactor(1)
+                .build();
+        broker.createTopics(List.of(topic));
     }
     
     @AfterEach
@@ -145,7 +145,7 @@ public class FluxParallelProducerTest {
         // Verify messages were received by the broker
         int totalMessages = 0;
         for (int i = 0; i < NUM_PARTITIONS; i++) {
-            int count = broker.getPartition(i).getCurrentOffset();
+            int count = broker.getPartition(TEST_TOPIC, i).getCurrentOffset();
             totalMessages += count;
             Logger.info("Partition {} received {} messages", i, count);
         }

--- a/src/test/java/broker/UniquePartitionIdsPerTopicTest.java
+++ b/src/test/java/broker/UniquePartitionIdsPerTopicTest.java
@@ -1,0 +1,135 @@
+package broker;
+
+import commons.FluxTopic;
+import metadata.InMemoryTopicMetadataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import server.internal.Broker;
+import server.internal.storage.Partition;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test to verify that partition IDs are unique per topic.
+ * Each topic should have its own partition ID space starting from 0.
+ */
+public class UniquePartitionIdsPerTopicTest {
+    
+    private Broker broker;
+    private InMemoryTopicMetadataRepository metadataRepo;
+    
+    @BeforeEach
+    public void setUp() throws IOException {
+        broker = new Broker("test-broker", "localhost", 50051, 2); // 2 default partitions
+        metadataRepo = InMemoryTopicMetadataRepository.getInstance();
+        // Reset the singleton instance
+        metadataRepo = InMemoryTopicMetadataRepository.reset();
+    }
+    
+    @Test
+    public void testPartitionIdsStartFromZeroForEachTopic() throws IOException {
+        // Create first topic with 3 partitions
+        proto.Topic topic1 = proto.Topic.newBuilder()
+                .setTopicName("topic-1")
+                .setNumPartitions(3)
+                .setReplicationFactor(1)
+                .build();
+        
+        broker.createTopics(List.of(topic1));
+        
+        // Create second topic with 5 partitions
+        proto.Topic topic2 = proto.Topic.newBuilder()
+                .setTopicName("topic-2")
+                .setNumPartitions(5)
+                .setReplicationFactor(1)
+                .build();
+        
+        broker.createTopics(List.of(topic2));
+        
+        // Verify topic-1 partitions have IDs 0, 1, 2
+        assertTrue(metadataRepo.topicExists("topic-1"));
+        List<Partition> topic1Partitions = metadataRepo.getPartitionsFor("topic-1");
+        assertNotNull(topic1Partitions);
+        assertEquals(3, topic1Partitions.size());
+        
+        for (int i = 0; i < 3; i++) {
+            assertEquals(i, topic1Partitions.get(i).getPartitionId(),
+                    "topic-1 partition " + i + " should have ID " + i);
+        }
+        
+        // Verify topic-2 partitions have IDs 0, 1, 2, 3, 4
+        assertTrue(metadataRepo.topicExists("topic-2"));
+        List<Partition> topic2Partitions = metadataRepo.getPartitionsFor("topic-2");
+        assertNotNull(topic2Partitions);
+        assertEquals(5, topic2Partitions.size());
+        
+        for (int i = 0; i < 5; i++) {
+            assertEquals(i, topic2Partitions.get(i).getPartitionId(),
+                    "topic-2 partition " + i + " should have ID " + i);
+        }
+        
+        // Verify that partition IDs are NOT contiguous across topics
+        // topic-1 has IDs 0-2, topic-2 also has IDs 0-4 (not 3-7)
+        assertNotEquals(3, topic2Partitions.get(0).getPartitionId(),
+                "topic-2's first partition should NOT start at ID 3");
+    }
+    
+    @Test
+    public void testPartitionAccessByTopicAndId() throws IOException {
+        // Create a topic
+        proto.Topic topic = proto.Topic.newBuilder()
+                .setTopicName("test-topic")
+                .setNumPartitions(4)
+                .setReplicationFactor(1)
+                .build();
+        
+        broker.createTopics(List.of(topic));
+        
+        // Test accessing partitions by topic and ID
+        for (int i = 0; i < 4; i++) {
+            Partition partition = broker.getPartition("test-topic", i);
+            assertNotNull(partition);
+            assertEquals(i, partition.getPartitionId());
+        }
+        
+        // Test that accessing invalid partition ID throws exception
+        assertThrows(IllegalArgumentException.class, () -> {
+            broker.getPartition("test-topic", 4); // Out of range
+        });
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            broker.getPartition("test-topic", -1); // Negative ID
+        });
+    }
+    
+    @Test
+    public void testPartitionIdRangesPerTopic() throws IOException {
+        // Create multiple topics
+        proto.Topic topic1 = proto.Topic.newBuilder()
+                .setTopicName("range-test-1")
+                .setNumPartitions(3)
+                .setReplicationFactor(1)
+                .build();
+        
+        proto.Topic topic2 = proto.Topic.newBuilder()
+                .setTopicName("range-test-2")
+                .setNumPartitions(7)
+                .setReplicationFactor(1)
+                .build();
+        
+        broker.createTopics(List.of(topic1));
+        broker.createTopics(List.of(topic2));
+        
+        // Verify partition ID ranges
+        var range1 = metadataRepo.getPartitionIdRangeForTopic("range-test-1");
+        assertEquals(0, range1.start(), "range-test-1 should start at ID 0");
+        assertEquals(2, range1.end(), "range-test-1 should end at ID 2");
+        
+        var range2 = metadataRepo.getPartitionIdRangeForTopic("range-test-2");
+        assertEquals(0, range2.start(), "range-test-2 should start at ID 0");
+        assertEquals(6, range2.end(), "range-test-2 should end at ID 6");
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented unique partition ID ranges per topic (each topic's partitions start from 0)
- Refactored Broker to use topic-specific partition management
- Updated all related services and tests to support topic-aware partition access

## Changes
- **Broker.java**: Changed from global partition list to `Map<String, List<Partition>>` for topic-specific partitions
- **IntermediaryRecord**: Added `topicName` field to properly route messages
- **Services**: Updated ProducerServiceImpl and ConsumerServiceImpl to handle topic-specific operations
- **Tests**: Added UniquePartitionIdsPerTopicTest with test coverage for the new functionality

## Issue Reference
Closes #88

## Testing
- Added comprehensive tests in UniquePartitionIdsPerTopicTest.java
- Updated existing tests to work with new API
- Verified partition IDs are unique per topic and start from 0