### PR TITLE
94 consumer groups protocolassignors

### DIFF
--- a/src/main/java/commons/TopicPartition.java
+++ b/src/main/java/commons/TopicPartition.java
@@ -1,4 +1,4 @@
-package producer;
+package commons;
 
 import java.util.Objects;
 

--- a/src/main/java/consumer/FluxConsumer.java
+++ b/src/main/java/consumer/FluxConsumer.java
@@ -196,8 +196,12 @@ public class FluxConsumer<K, V> implements Consumer {
         Map<String, Integer> counts = new HashMap<>();
         for (String t : topics) {
             if (t != null && !t.isEmpty()) {
-                IntRange ranges = InMemoryTopicMetadataRepository.getInstance().getPartitionIdRangeForTopic(t);
-                counts.put(t, ranges.end() - ranges.start() + 1);
+                try {
+                    IntRange ranges = InMemoryTopicMetadataRepository.getInstance().getPartitionIdRangeForTopic(t);
+                    counts.put(t, ranges.end() - ranges.start() + 1);
+                } catch (IllegalArgumentException e) {
+                    Logger.warn("Topic {} not found: {}", t, e.getMessage());
+                }
             }
         }
         return counts;

--- a/src/main/java/consumer/assignors/RangeAssignor.java
+++ b/src/main/java/consumer/assignors/RangeAssignor.java
@@ -1,10 +1,14 @@
 package consumer.assignors;
 
-import consumer.assignors.PartitionAssignor;
-
 import java.util.*;
 
-// TODO: Investigate RangeAssignor
+/**
+ * RangeAssignor:
+ * For each topic independently:
+ *  - Sort members and assign each member one contiguous "range" of partitions.
+ *  - If partitions don't divide evenly, the first (count % numMembers) members get one extra.
+ * Output shape: memberId -> (topic -> List(partitionIds)).
+ */
 public final class RangeAssignor implements PartitionAssignor {
 
     @Override
@@ -12,6 +16,63 @@ public final class RangeAssignor implements PartitionAssignor {
             List<String> memberIds,
             Map<String, Integer> topicToPartitionCount
     ) {
-        return null;
+
+        if (
+                memberIds == null || memberIds.isEmpty() ||
+                topicToPartitionCount == null || topicToPartitionCount.isEmpty()
+        ) {
+            return Collections.emptyMap();
+        }
+
+        List<String> members = new ArrayList<>(memberIds);
+        List<String> topics = new ArrayList<>(topicToPartitionCount.keySet());
+
+        Collections.sort(members);
+        Collections.sort(topics);
+
+        // member -> topic -> partitions
+        Map<String, Map<String, List<Integer>>> result = new LinkedHashMap<>();
+        for (String m : members) {
+            result.put(m, new LinkedHashMap<>());
+        }
+
+        // Assign ranges per topic
+        for (String topic : topics) {
+            int partitionCount = Math.max(0, topicToPartitionCount.getOrDefault(topic, 0));
+            if (partitionCount == 0) {
+                // still create empty lists for determinism if desired; safe to skip as well
+                continue;
+            }
+
+            int numMembers = members.size();
+            int base = partitionCount / numMembers; // MIN PER MEMBER
+            int extra = partitionCount % numMembers; // first EXTRA members get an extra one.
+
+            int nextStart = 0;
+            for (int i = 0; i < numMembers; i++) {
+                int len = base + (i < extra ? 1 : 0);
+
+                // if size is zero, this member gets none for this topic
+                if (len > 0) {
+                    List<Integer> range = new ArrayList<>(len);
+                    for (int p = nextStart; p < nextStart + len; p++) {
+                        range.add(p);
+                    }
+                    result.get(members.get(i))
+                            .computeIfAbsent(topic, t -> new ArrayList<>())
+                            .addAll(range);
+                    nextStart += len;
+                }
+            }
+        }
+
+        // freeze the lists
+        for (Map<String, List<Integer>> byTopic : result.values()) {
+            for (Map.Entry<String, List<Integer>> e : byTopic.entrySet()) {
+                e.setValue(Collections.unmodifiableList(e.getValue()));
+            }
+        }
+
+        return result;
     }
 }

--- a/src/main/java/consumer/assignors/RoundRobinAssignor.java
+++ b/src/main/java/consumer/assignors/RoundRobinAssignor.java
@@ -1,6 +1,6 @@
 package consumer.assignors;
 
-import producer.TopicPartition;
+import commons.TopicPartition;
 
 import java.util.*;
 

--- a/src/main/java/consumer/assignors/RoundRobinAssignor.java
+++ b/src/main/java/consumer/assignors/RoundRobinAssignor.java
@@ -1,14 +1,76 @@
 package consumer.assignors;
 
+import producer.TopicPartition;
+
 import java.util.*;
 
-// TODO: Investigate RoundRobinAssignor
+/**
+ * Round-robin assignor
+ * 1) Sort memberIds
+ * 2) Expand topicToPartitionCount into a flatten sorted list of (topic, partitionId).
+ * 3) Deal partitions to members in a cycle
+ * 4) Return map: memberId -> (topic -> list(partitionIds)).
+ */
 public final class RoundRobinAssignor implements PartitionAssignor {
     @Override
     public Map<String, Map<String, List<Integer>>> assign(
             List<String> memberIds,
             Map<String, Integer> topicToPartitionCount
     ) {
-        return null;
+        // Edge cases
+        if (
+            memberIds == null || memberIds.isEmpty() ||
+            topicToPartitionCount == null || topicToPartitionCount.isEmpty()
+        ) {
+            return Collections.emptyMap();
+        }
+
+        // Deterministic order of members & topics
+        List<String> members = new ArrayList<>(memberIds);
+        Collections.sort(members);
+
+        List<String> topics = new ArrayList<>(topicToPartitionCount.keySet());
+        Collections.sort(topics);
+
+        // Flatten into (topic, partitionId) list in deterministic order
+        List<TopicPartition> all = new ArrayList<>();
+        for (String topic : topics) {
+            int count = topicToPartitionCount.getOrDefault(topic, 0);
+            for (int p = 0; p < count; p++) {
+                all.add(new TopicPartition(topic, p));
+            }
+        }
+
+        // If no partitions at all, return empty assignments for each member
+        if (all.isEmpty()) {
+            Map<String, Map<String, List<Integer>>> empty = new LinkedHashMap<>();
+            for (String m : members) {
+                empty.put(m, Collections.emptyMap());
+            }
+            return empty;
+        }
+
+        // Prepare result structure: member -> topic -> partitions
+        Map<String, Map<String, List<Integer>>> result = new LinkedHashMap<>();
+        for (String m : members) {
+            result.put(m, new LinkedHashMap<>());
+        }
+
+        // Deal out in round-robin
+        int i = 0;
+        for (TopicPartition tp : all) {
+            String member = members.get(i % members.size());
+            Map<String, List<Integer>> byTopic = result.get(member);
+            byTopic.computeIfAbsent(tp.getTopic(), t -> new ArrayList<>()).add(tp.getPartition());
+            i++;
+        }
+
+        //  Wrap per-topic lists as unmodifiable for safety
+        for (Map<String, List<Integer>> byTopic : result.values()) {
+            for (Map.Entry<String, List<Integer>> e : byTopic.entrySet()) {
+                e.setValue(Collections.unmodifiableList(e.getValue()));
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/consumer/assignors/StickyAssignor.java
+++ b/src/main/java/consumer/assignors/StickyAssignor.java
@@ -87,6 +87,6 @@ public class StickyAssignor implements PartitionAssignor {
             List<String> memberIds,
             Map<String, Integer> topicToPartitionCount
     ) {
-        return null;
+        throw new UnsupportedOperationException("StickyAssignor not implemented yet");
     }
 }

--- a/src/main/java/consumer/assignors/StickyAssignor.java
+++ b/src/main/java/consumer/assignors/StickyAssignor.java
@@ -3,7 +3,84 @@ package consumer.assignors;
 import java.util.*;
 
 
-// TODO: Investigate StickyAssignor
+// TODO: Worthwhile to make into its own story for later. Just becuz future research is needed.
+// TODO: I will document what I found however
+/*
+    This is the HIGH LEVEL algo/steps from good mutually agreed from both LLMs and Youtube Confluent.
+
+    GOALS:
+        1) Balanced: total partitions are split so each member has either ⌊P/M⌋ or ⌈P/M⌉.
+        2) Sticky: keep as many prior placements as possible; move only what’s necessary to reach (1).
+         Deterministic: same inputs → same output.
+
+    Data Structures:
+          - taken: HashSet<TopicPartition> of partitions already kept/assigned (prevents duplicates).
+          - unassigned: ArrayDeque<TopicPartition> (FIFO) holding partitions that must be (re)assigned.
+          - result: Map<memberId, Map<topic, List<Integer>>> accumulating the plan.
+          - desired[]: int[M] target load per member (balanced totals).
+          - load[]:    int[M] current load per member after “keep” step.
+          - pq: PriorityQueue<MemberSlot> — a min-heap ordered by (load ASC, memberIndex ASC).
+          -  MemberSlot { index:int, load:int, desired:int }.
+
+   STEPS:
+           0) Normalize for determinism:
+                - Sort memberIds; sort topics.
+
+             1) Build the partition universe:
+                - allPartitions := sorted list of every (topic, partitionId) that exists now.
+
+             2) Compute balanced targets:
+                - total P = allPartitions.size(), members M = memberIds.size()
+                - base = P / M, extra = P % M
+                - desired[i] = base + (i < extra ? 1 : 0)  // first ‘extra’ members get one more
+
+             3) Keep valid previous assignments (stickiness pass):
+                - For each member in sorted order:
+                    For each (topic -> partitions) previously owned:
+                      For each partition p:
+                        If topic still exists AND 0 <= p < topicPartitionCount[topic]
+                        AND (topic,p) not in taken:
+                          - Append p to result[member][topic], mark taken.add((topic,p)).
+                - This preserves as much prior placement as possible without violating current realities.
+
+             4) Measure current load & collect unassigned:
+                - load[i] = sum of partitions already in result for member i.
+                - unassigned = every (topic,partition) in allPartitions that is NOT in taken.
+
+             5) Evict from overfull members (to achieve balance with minimal churn):
+                - For each member i:
+                    over = load[i] - desired[i]
+                    If over > 0:
+                      - Gather that member’s owned TopicPartitions (flatten & sort deterministically).
+                      - Remove ‘over’ partitions from the END (highest (topic,partition) first) to be victims.
+                      - For each victim:
+                          * Remove from result[member]
+                          * taken.remove(victim)
+                          * unassigned.addLast(victim)
+                          * load[i]--
+                - Eviction is deterministic and limited to what’s strictly necessary.
+
+             6) Fill underfull members using a MIN-HEAP (the “heap” part):
+                - Initialize pq with MemberSlot(i, load[i], desired[i]) for any i where load[i] < desired[i].
+                - While unassigned not empty AND pq not empty:
+                    tp = unassigned.pollFirst()         // pick next unassigned partition in stable order
+                    ms = pq.poll()                      // pop least-loaded member (min-heap by load, then index)
+                    assign tp to memberIds[ms.index]    // result[member][tp.topic].add(tp.partition)
+                    ms.load++
+                    If ms.load < ms.desired:
+                       pq.add(ms)                       // still needs more; push back with updated load
+                - The min-heap ensures each partition goes to the *currently* least-loaded member,
+                  guaranteeing balance while minimizing further movement.
+
+             7) Canonicalize & freeze:
+                - Sort each member’s per-topic partition lists; optionally wrap them unmodifiable.
+
+         Edge Cases:
+          - No members or no partitions → empty assignment map.
+          - More members than partitions → some members end at 0 (desired[i] may be 0).
+          - Topic shrinks or disappears → invalid prior partitions are ignored automatically in step 3.
+ */
+
 public class StickyAssignor implements PartitionAssignor {
     @Override
     public Map<String, Map<String, List<Integer>>> assign(

--- a/src/main/java/producer/RecordAccumulator.java
+++ b/src/main/java/producer/RecordAccumulator.java
@@ -1,6 +1,6 @@
 package producer;
 
-import commons.CompressionType;
+import commons.TopicPartition;
 import commons.utils.PartitionSelector;
 import metadata.InMemoryTopicMetadataRepository;
 import metadata.Metadata;
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/server/internal/Broker.java
+++ b/src/main/java/server/internal/Broker.java
@@ -95,10 +95,10 @@ public class Broker implements Controller {
                 this.numPartitions++;
             }
             this.topicPartitions.put(topicName, newTopicPartitions);
-
-        FluxTopic topic = new FluxTopic(topicName, newTopicPartitions, replicationFactor);
-        InMemoryTopicMetadataRepository.getInstance().addNewTopic(topicName, topic);
-        Logger.info("BROKER: Create topics completed successfully.");
+            FluxTopic topic = new FluxTopic(topicName, newTopicPartitions, replicationFactor);
+            InMemoryTopicMetadataRepository.getInstance().addNewTopic(topicName, topic);
+            Logger.info("BROKER: Create topics completed successfully.");
+        }
     }
 
     @Override

--- a/src/test/java/consumer/assignors/RangeAssignorTest.java
+++ b/src/test/java/consumer/assignors/RangeAssignorTest.java
@@ -1,0 +1,167 @@
+package consumer.assignors;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RangeAssignorTest {
+
+    private final RangeAssignor assignor = new RangeAssignor();
+
+    @Test
+    void emptyInputs_returnEmpty() {
+        assertTrue(assignor.assign(Collections.emptyList(), Map.of("t", 3)).isEmpty());
+        assertTrue(assignor.assign(List.of("m1"), Collections.emptyMap()).isEmpty());
+        assertTrue(assignor.assign(Collections.emptyList(), Collections.emptyMap()).isEmpty());
+        assertTrue(assignor.assign(null, Map.of("t", 1)).isEmpty());
+    }
+
+    @Test
+    void singleTopic_evenlyDivisible_contiguousRanges() {
+        // 6 partitions, 3 members -> each gets 2: [0,1], [2,3], [4,5]
+        List<String> members = List.of("c", "a", "b"); // unsorted on purpose
+        Map<String, Integer> counts = Map.of("t", 6);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        assertEquals(List.of(0, 1), r.get("a").get("t"));
+        assertEquals(List.of(2, 3), r.get("b").get("t"));
+        assertEquals(List.of(4, 5), r.get("c").get("t"));
+
+        assertTrue(isContiguous(r.get("a").get("t")));
+        assertTrue(isContiguous(r.get("b").get("t")));
+        assertTrue(isContiguous(r.get("c").get("t")));
+        assertEquals(Set.of(0,1,2,3,4,5), ownedSet(r, "t"));
+    }
+
+    @Test
+    void singleTopic_notEven_firstExtraMembersGetOneMore() {
+        // 5 partitions, 3 members => base=1, extra=2 -> a:2, b:2, c:1
+        List<String> members = List.of("c", "a", "b");
+        Map<String, Integer> counts = Map.of("t", 5);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        // members sorted: [a,b,c]; nextStart runs left->right
+        assertEquals(List.of(0, 1), r.get("a").get("t"));
+        assertEquals(List.of(2, 3), r.get("b").get("t"));
+        assertEquals(List.of(4),     r.get("c").get("t"));
+
+        assertTrue(isContiguous(r.get("a").get("t")));
+        assertTrue(isContiguous(r.get("b").get("t")));
+        assertTrue(isContiguous(r.get("c").get("t")));
+        assertEquals(Set.of(0,1,2,3,4), ownedSet(r, "t"));
+    }
+
+    @Test
+    void multipleTopics_independentRangesPerTopic() {
+        // topics sorted: bar, foo
+        // foo has 5 parts -> a:2, b:2, c:1
+        // bar has 2 parts -> a:1, b:1, c:0
+        List<String> members = List.of("c", "b", "a");
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("bar", 2);
+        counts.put("foo", 5);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        // foo (5 → a:[0,1], b:[2,3], c:[4])
+        assertEquals(List.of(0, 1), r.get("a").get("foo"));
+        assertEquals(List.of(2, 3), r.get("b").get("foo"));
+        assertEquals(List.of(4),     r.get("c").get("foo"));
+
+        // bar (2 → a:[0], b:[1], c:[])
+        assertEquals(List.of(0), r.get("a").get("bar"));
+        assertEquals(List.of(1), r.get("b").get("bar"));
+        assertFalse(r.get("c").containsKey("bar"));
+
+        // contiguity checks
+        assertTrue(isContiguous(r.get("a").get("foo")));
+        assertTrue(isContiguous(r.get("b").get("foo")));
+        assertTrue(isContiguous(r.get("c").get("foo")));
+        assertTrue(isContiguous(r.get("a").get("bar")));
+        assertTrue(isContiguous(r.get("b").get("bar")));
+
+        //  every partition assigned exactly once per topic
+        assertEquals(Set.of(0,1,2,3,4), ownedSet(r, "foo"));
+        assertEquals(Set.of(0,1), ownedSet(r, "bar"));
+    }
+
+
+    @Test
+    void moreMembersThanPartitions_someMembersGetNone() {
+        List<String> members = List.of("D", "C", "B", "A"); // will sort to A,B,C,D
+        Map<String, Integer> counts = Map.of("t", 2);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        assertEquals(List.of(0), r.get("A").get("t"));
+        assertEquals(List.of(1), r.get("B").get("t"));
+        assertTrue(r.get("C").isEmpty());
+        assertTrue(r.get("D").isEmpty());
+    }
+
+    @Test
+    void determinism_sameInputs_sameOutputs() {
+        List<String> members = List.of("x", "y", "z");
+        Map<String, Integer> counts = Map.of("alpha", 4, "beta", 3);
+
+        var r1 = assignor.assign(members, counts);
+        var r2 = assignor.assign(members, counts);
+
+        assertEquals(r1, r2);
+    }
+
+    @Test
+    void listsAreUnmodifiable() {
+        List<String> members = List.of("m1", "m2");
+        Map<String, Integer> counts = Map.of("t", 3);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        assertThrows(UnsupportedOperationException.class, () -> r.get("m1").get("t").add(99));
+    }
+
+    @Test
+    void balancePerTopic_firstExtrasGetTheRemainder() {
+        List<String> members = List.of("a", "b", "c");
+        Map<String, Integer> counts = Map.of("A", 7, "B", 2); // A: base=2, extra=1 -> [3,2,2]; B: base=0, extra=2 -> [1,1,0]
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, counts);
+
+        // A
+        assertEquals(3, sizeOrZero(r.get("a").get("A")));
+        assertEquals(2, sizeOrZero(r.get("b").get("A")));
+        assertEquals(2, sizeOrZero(r.get("c").get("A")));
+        // B
+        assertEquals(1, sizeOrZero(r.get("a").get("B")));
+        assertEquals(1, sizeOrZero(r.get("b").get("B")));
+        assertEquals(0, sizeOrZero(r.get("c").get("B")));
+    }
+
+    // HELPERS
+    private static boolean isContiguous(List<Integer> parts) {
+        if (parts == null || parts.isEmpty()) return true;
+        List<Integer> tmp = new ArrayList<>(parts);
+        Collections.sort(tmp);
+        for (int i = 1; i < tmp.size(); i++) {
+            if (tmp.get(i) != tmp.get(i - 1) + 1) return false;
+        }
+        return true;
+    }
+
+    private static Set<Integer> ownedSet(Map<String, Map<String, List<Integer>>> r, String topic) {
+        Set<Integer> s = new HashSet<>();
+        for (Map<String, List<Integer>> byTopic : r.values()) {
+            List<Integer> lst = byTopic.get(topic);
+            if (lst != null) s.addAll(lst);
+        }
+        return s;
+    }
+
+    private static int sizeOrZero(List<Integer> lst) {
+        return lst == null ? 0 : lst.size();
+    }
+}

--- a/src/test/java/consumer/assignors/RoundRobinAssignorTest.java
+++ b/src/test/java/consumer/assignors/RoundRobinAssignorTest.java
@@ -1,0 +1,132 @@
+package consumer.assignors;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RoundRobinAssignorTest {
+
+    private final RoundRobinAssignor assignor = new RoundRobinAssignor();
+
+    @Test
+    void emptyMembersOrTopics_returnsEmpty() {
+        Map<String, Map<String, List<Integer>>> a =
+                assignor.assign(Collections.emptyList(), Map.of("t", 3));
+        Map<String, Map<String, List<Integer>>> b = assignor.assign(List.of("m1", "m2"), Collections.emptyMap());
+        assertTrue(a.isEmpty());
+        assertTrue(b.isEmpty());
+    }
+
+    @Test
+    void singleTopic_evenDistribution_roundRobinOrder() {
+        List<String> members = List.of("c", "a", "b"); // UNSORTED
+        Map<String, Integer> topicCounts = Map.of("orders", 6);
+
+        Map<String, Map<String, List<Integer>>> result = assignor.assign(members, topicCounts);
+
+        // members are sorted inside assignor → [a, b, c]
+        assertEquals(List.of(0, 3), result.get("a").get("orders"));
+        assertEquals(List.of(1, 4), result.get("b").get("orders"));
+        assertEquals(List.of(2, 5), result.get("c").get("orders"));
+
+        // each member gets exactly 2
+        assertEquals(2, totalOwned(result, "a"));
+        assertEquals(2, totalOwned(result, "b"));
+        assertEquals(2, totalOwned(result, "c"));
+    }
+
+    @Test
+    void multipleTopics_respectsSortedTopicThenPartitionOrder() {
+        // topics will be iterated in alpha, then beta
+        Map<String, Integer> topicCounts = new LinkedHashMap<>();
+        topicCounts.put("beta", 3);
+        topicCounts.put("alpha", 2);
+
+        List<String> members = List.of("m2", "m1"); // UNSORTED
+
+        Map<String, Map<String, List<Integer>>> result =
+                assignor.assign(members, topicCounts);
+
+        // deterministic member order is [m1, m2]
+        // flattened partitions in order: alpha-0, alpha-1, beta-0, beta-1, beta-2
+        // deal to m1, m2, m1, m2, m1
+        assertEquals(List.of(0), result.get("m1").get("alpha"));
+        assertEquals(List.of(1), result.get("m2").get("alpha"));
+        assertEquals(List.of(0, 2), result.get("m1").get("beta"));
+        assertEquals(List.of(1), result.get("m2").get("beta"));
+
+        assertEquals(3, totalOwned(result, "m1"));
+        assertEquals(2, totalOwned(result, "m2"));
+    }
+
+    @Test
+    void moreMembersThanPartitions_someMembersGetZero() {
+        List<String> members = List.of("A", "B", "C", "D");
+        Map<String, Integer> topics = Map.of("t", 2);
+
+        Map<String, Map<String, List<Integer>>> result =
+                assignor.assign(members, topics);
+
+        // sorted members: A, B, C, D
+        assertEquals(List.of(0), result.get("A").get("t"));
+        assertEquals(List.of(1), result.get("B").get("t"));
+        assertTrue(result.get("C").isEmpty());
+        assertTrue(result.get("D").isEmpty());
+    }
+
+    @Test
+    void determinism_sameInputs_sameOutputs() {
+        List<String> members = List.of("x", "y", "z");
+        Map<String, Integer> topics = Map.of("a", 2, "b", 4, "c", 1);
+
+        Map<String, Map<String, List<Integer>>> r1 = assignor.assign(members, topics);
+        Map<String, Map<String, List<Integer>>> r2 = assignor.assign(members, topics);
+
+        assertEquals(r1, r2);
+    }
+
+    @Test
+    void listsAreUnmodifiable() {
+        List<String> members = List.of("m1", "m2");
+        Map<String, Integer> topics = Map.of("t", 3);
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, topics);
+        List<Integer> m1List = r.get("m1").get("t");
+
+        assertThrows(UnsupportedOperationException.class, () -> m1List.add(99));
+    }
+
+    @Test
+    void balanceProperty_eachMemberGetsFloorOrCeil() {
+        List<String> members = List.of("a", "b", "c");
+        Map<String, Integer> topics = Map.of(
+                "A", 5,
+                "B", 2,
+                "C", 4
+        );
+        int totalP = topics.values().stream().mapToInt(i -> i).sum(); // 11
+        int M = members.size();
+        int base = totalP / M;   // 11/3 = 3
+        int ceil = (totalP + M - 1) / M; // 4
+
+        Map<String, Map<String, List<Integer>>> r = assignor.assign(members, topics);
+
+        for (String m : members) {
+            int owned = totalOwned(r, m);
+            assertTrue(owned == base || owned == ceil,
+                    () -> "member " + m + " owns " + owned + " which is not in {"
+                            + base + "," + ceil + "}");
+        }
+    }
+    private static int totalOwned(Map<String, Map<String, List<Integer>>> result, String member) {
+        Map<String, List<Integer>> byTopic = result.get(member);
+        if (byTopic == null) return 0;
+        int sum = 0;
+        for (List<Integer> lst : byTopic.values()) {
+            sum += lst.size();
+        }
+        return sum;
+    }
+}

--- a/src/test/java/producer/BatchExpiryTest.java
+++ b/src/test/java/producer/BatchExpiryTest.java
@@ -1,6 +1,6 @@
 package producer;
 
-import commons.header.Header;
+import commons.TopicPartition;
 import commons.headers.Headers;
 import commons.utils.PartitionSelector;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/producer/DrainReadyLogicTest.java
+++ b/src/test/java/producer/DrainReadyLogicTest.java
@@ -1,6 +1,7 @@
 package producer;
 
 import commons.CompressionType;
+import commons.TopicPartition;
 import commons.headers.Headers;
 import metadata.Metadata;
 import metadata.snapshots.ClusterSnapshot;

--- a/src/test/java/producer/InFlightTrackingTest.java
+++ b/src/test/java/producer/InFlightTrackingTest.java
@@ -1,6 +1,6 @@
 package producer;
 
-import commons.header.Header;
+import commons.TopicPartition;
 import commons.headers.Headers;
 import commons.utils.PartitionSelector;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/producer/RecordAccumulatorTest.java
+++ b/src/test/java/producer/RecordAccumulatorTest.java
@@ -1,6 +1,7 @@
 package producer;
 
 import commons.CompressionType;
+import commons.TopicPartition;
 import commons.header.Header;
 import commons.headers.Headers;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 

--- a/src/test/java/producer/RetryMechanismTest.java
+++ b/src/test/java/producer/RetryMechanismTest.java
@@ -1,10 +1,9 @@
 package producer;
 
+import commons.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import java.util.Properties;
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
## Description
- This PR takes RoundRobin and Range for Assignors class. 
- I honestly couldn't get the `StickyAssignor` it requires a complicated heap approach and I think its worthwhile to make it into a new story. I did however, write some documented research I found online.
### Round Robin
- Flattens all partitions across all topics into a single ordered list (topic name + partition number) hands them out one by one to members in a cycle (m1 → m2 → … → mN → m1 → …)
- Balances globally across topics.
- Good for large numbers of partitions/members where fairness matters most.
- Deterministic if members and topics are sorted first.

### Range
- Starts from the previous assignment, keeps as many partitions with the same member as possible, then only moves partitions if needed to restore balance. Uses a least-loaded strategy (heap) to fill underfull members.
- Ensures max load difference ≤ 1 (balance first), but minimizes how many partitions actually move.
- Produces deterministic results when members/topics are sorted.
- Ideal for reducing costly state migrations in stateful consumers (e.g., Kafka Streams).